### PR TITLE
[#43] - 업로드 페이지 퍼블리싱, 업로드 컴포넌트 스타일 적용, 라우팅 기본 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react-dropzone": "^14.3.5",
     "react-hook-form": "^7.54.2",
     "zod": "^3.24.2",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "react-router": "^7.1.5"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       react-icons:
         specifier: ^5.5.0
         version: 5.5.0(react@18.3.1)
+      react-router:
+        specifier: ^7.1.5
+        version: 7.1.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^3.2.4
@@ -2698,6 +2701,12 @@ packages:
         integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==,
       }
 
+  '@types/cookie@0.6.0':
+    resolution:
+      {
+        integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==,
+      }
+
   '@types/doctrine@0.0.9':
     resolution:
       {
@@ -3575,6 +3584,13 @@ packages:
       {
         integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
       }
+
+  cookie@1.0.2:
+    resolution:
+      {
+        integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==,
+      }
+    engines: { node: '>=18' }
 
   core-js-compat@3.40.0:
     resolution:
@@ -6124,6 +6140,19 @@ packages:
       '@types/react':
         optional: true
 
+  react-router@7.1.5:
+    resolution:
+      {
+        integrity: sha512-8BUF+hZEU4/z/JD201yK6S+UYhsf58bzYIDq2NS1iGpwxSXDu7F+DeGSkIXMFBuHZB21FSiCzEcUb18cQNdRkA==,
+      }
+    engines: { node: '>=20.0.0' }
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-style-singleton@2.2.3:
     resolution:
       {
@@ -6373,6 +6402,12 @@ packages:
     resolution:
       {
         integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==,
+      }
+
+  set-cookie-parser@2.7.1:
+    resolution:
+      {
+        integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==,
       }
 
   set-function-length@1.2.2:
@@ -7015,6 +7050,12 @@ packages:
     resolution:
       {
         integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
+      }
+
+  turbo-stream@2.4.0:
+    resolution:
+      {
+        integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==,
       }
 
   tween-functions@1.2.0:
@@ -9388,6 +9429,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.7
 
+  '@types/cookie@0.6.0': {}
+
   '@types/doctrine@0.0.9': {}
 
   '@types/dompurify@3.2.0':
@@ -9959,6 +10002,8 @@ snapshots:
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.0.2: {}
 
   core-js-compat@3.40.0:
     dependencies:
@@ -11525,6 +11570,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.18
 
+  react-router@7.1.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@types/cookie': 0.6.0
+      cookie: 1.0.2
+      react: 18.3.1
+      set-cookie-parser: 2.7.1
+      turbo-stream: 2.4.0
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
   react-style-singleton@2.2.3(@types/react@18.3.18)(react@18.3.1):
     dependencies:
       get-nonce: 1.0.1
@@ -11703,6 +11758,8 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  set-cookie-parser@2.7.1: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -12170,6 +12227,8 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  turbo-stream@2.4.0: {}
 
   tween-functions@1.2.0: {}
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,13 +1,15 @@
+import { RouterProvider } from 'react-router';
+
 import { Global } from '@emotion/react';
 
-import TotalEvalutionPage from './features/total-evaluation/total-evaluation-page';
+import { router } from './route';
 import { globalStyles } from './styles/global-styles';
 
 function App() {
   return (
     <div>
       <Global styles={globalStyles} />
-      <TotalEvalutionPage />
+      <RouterProvider router={router} />
     </div>
   );
 }

--- a/src/features/upload/components/file-upload/file-upload.styles.ts
+++ b/src/features/upload/components/file-upload/file-upload.styles.ts
@@ -1,0 +1,48 @@
+import { css } from '@emotion/react';
+
+export const form = css`
+  position: relative;
+`;
+
+export const container = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 88.9rem;
+  height: 10.5rem;
+  border: 1px solid #ccc;
+  border-radius: 2rem;
+  background-color: #efefef;
+`;
+
+export const preview = css`
+  color: #484848;
+  font-size: 24px;
+  font-weight: 600;
+  text-align: center;
+  line-height: normal;
+  letter-spacing: -0.48px;
+`;
+
+export const uploadButton = css`
+  position: absolute;
+  right: 2.8rem;
+  width: 4.8rem;
+  height: 4.8rem;
+  background-color: #c5c5c5;
+  border: none;
+  border-radius: 999rem;
+  outline: none;
+
+  &:hover {
+    background-color: rgb(172 172 172);
+  }
+`;
+
+export const errorText = css`
+  position: absolute;
+  top: 100%;
+  color: red;
+  font-size: 1.6rem;
+`;

--- a/src/features/upload/components/file-upload/file-upload.tsx
+++ b/src/features/upload/components/file-upload/file-upload.tsx
@@ -1,10 +1,19 @@
+import { useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
-import { Controller, FieldValues, SubmitHandler, useForm } from 'react-hook-form';
+import {
+  Controller,
+  FieldValues,
+  SubmitErrorHandler,
+  SubmitHandler,
+  useForm,
+} from 'react-hook-form';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
 import { Button } from '../../../../common/components/button/Button';
+
+import * as styles from './file-upload.styles';
 
 const MAX_FILE_SIZE = 1024 * 1024 * 5;
 
@@ -19,6 +28,7 @@ export default function FileUpload({ ...props }) {
   const {
     handleSubmit,
     control,
+    watch,
     formState: { errors },
   } = useForm({
     resolver: zodResolver(schema),
@@ -30,15 +40,26 @@ export default function FileUpload({ ...props }) {
     console.log(data);
   };
 
+  const onSubmitError: SubmitErrorHandler<FieldValues> = (errors) => {
+    console.log('errors', errors);
+  };
+
+  const file = watch('file');
+
+  useEffect(() => {
+    if (!file) return;
+
+    handleSubmit(onSubmit, onSubmitError)();
+  }, [file, handleSubmit]);
+
   return (
-    <form onSubmit={handleSubmit(onSubmit, (error) => console.log('error', error))}>
+    <form css={styles.form}>
       <Controller
         name="file"
         control={control}
         render={({ field }) => <Dropzone {...props} onChange={field.onChange} />}
       />
-      {errors.file && <div>{errors.file.message?.toString()}</div>}
-      <button type="submit">제출</button>
+      {errors.file && <div css={styles.errorText}>{errors.file.message?.toString()}</div>}
     </form>
   );
 }
@@ -47,31 +68,46 @@ FileUpload.displayName = 'FileUpload';
 function Dropzone({ onChange }: { onChange?: (...event: unknown[]) => void }) {
   const { acceptedFiles, getInputProps, getRootProps, isDragActive, open } = useDropzone({
     noClick: true,
-    maxSize: MAX_FILE_SIZE,
     onDrop: (files) => {
       onChange?.(files[0]);
     },
   });
 
   return (
-    <div {...getRootProps()}>
+    <div {...getRootProps()} css={styles.container}>
       <input
         {...getInputProps({
           accept: 'application/pdf',
         })}
       />
 
-      <Button type="button" onClick={open}>
-        파일 업로드
+      <div css={styles.preview}>
+        {isDragActive ? (
+          <p>파일 업로드하기</p>
+        ) : (
+          acceptedFiles.length === 0 && <p>포트폴리오 PDF 업로드하기</p>
+        )}
+
+        <div>{acceptedFiles?.[0]?.name}</div>
+      </div>
+
+      <Button type="button" onClick={open} css={styles.uploadButton}>
+        {/* + svg 임시 사용 */}
+        <PlugSvg />
       </Button>
-
-      {isDragActive ? (
-        <p>파일을 놓아주세요</p>
-      ) : (
-        acceptedFiles.length === 0 && <p>또는 드래그 해서 업로드</p>
-      )}
-
-      {acceptedFiles?.[0]?.name}
     </div>
+  );
+}
+
+function PlugSvg() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M20.318 10.8H13.318V3.79998C13.318 3.48172 13.1916 3.17649 12.9665 2.95145C12.7415 2.7264 12.4363 2.59998 12.118 2.59998C11.7998 2.59998 11.4945 2.7264 11.2695 2.95145C11.0444 3.17649 10.918 3.48172 10.918 3.79998V10.8H3.91802C3.59976 10.8 3.29453 10.9264 3.06949 11.1514C2.84445 11.3765 2.71802 11.6817 2.71802 12C2.71802 12.3182 2.84445 12.6235 3.06949 12.8485C3.29453 13.0735 3.59976 13.2 3.91802 13.2H10.918V20.2C10.918 20.5182 11.0444 20.8235 11.2695 21.0485C11.4945 21.2735 11.7998 21.4 12.118 21.4C12.4363 21.4 12.7415 21.2735 12.9665 21.0485C13.1916 20.8235 13.318 20.5182 13.318 20.2V13.2H20.318C20.6363 13.2 20.9415 13.0735 21.1665 12.8485C21.3916 12.6235 21.518 12.3182 21.518 12C21.518 11.6817 21.3916 11.3765 21.1665 11.1514C20.9415 10.9264 20.6363 10.8 20.318 10.8Z"
+        fill="#8B95A1"
+      />
+    </svg>
   );
 }

--- a/src/features/upload/components/file-upload/file-upload.tsx
+++ b/src/features/upload/components/file-upload/file-upload.tsx
@@ -88,7 +88,7 @@ function Dropzone({ onChange }: { onChange?: (...event: unknown[]) => void }) {
           acceptedFiles.length === 0 && <p>포트폴리오 PDF 업로드하기</p>
         )}
 
-        <div>{acceptedFiles?.[0]?.name}</div>
+        {!isDragActive && <div>{acceptedFiles?.[0]?.name}</div>}
       </div>
 
       <Button type="button" onClick={open} css={styles.uploadButton}>

--- a/src/features/upload/upload-page.styles.ts
+++ b/src/features/upload/upload-page.styles.ts
@@ -1,0 +1,35 @@
+import { css } from '@emotion/react';
+
+export const container = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  width: 100dvw;
+  height: 100dvh;
+`;
+
+export const logo = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 11.7rem;
+  height: 6.5rem;
+  color: #969696;
+  font-size: 2.4rem;
+  font-weight: 600;
+  text-align: center;
+  background-color: #d9d9d9;
+  border-radius: 2.4rem;
+  font-style: normal;
+  letter-spacing: -0.048rem;
+`;
+
+export const title = css`
+  margin: 5.6rem 0;
+  color: #000;
+  font-size: 4rem;
+  font-weight: 600;
+  text-align: center;
+  letter-spacing: -0.08rem;
+`;

--- a/src/features/upload/upload-page.tsx
+++ b/src/features/upload/upload-page.tsx
@@ -1,0 +1,13 @@
+import FileUpload from './components/file-upload/file-upload';
+
+import * as styles from './upload-page.styles';
+
+export default function UploadPage() {
+  return (
+    <div css={styles.container}>
+      <div css={styles.logo}>Logo</div>
+      <h1 css={styles.title}>포트폴리오를 업그레이드 해볼까요?</h1>
+      <FileUpload />
+    </div>
+  );
+}

--- a/src/route.tsx
+++ b/src/route.tsx
@@ -1,0 +1,23 @@
+import { createBrowserRouter } from 'react-router';
+
+import TotalEvalutionPage from './features/total-evaluation/total-evaluation-page';
+import UploadPage from './features/upload/upload-page';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: (
+      <div>
+        <h1>메인 페이지</h1>
+      </div>
+    ),
+  },
+  {
+    path: '/upload',
+    element: <UploadPage />,
+  },
+  {
+    path: '/total-evaluation',
+    element: <TotalEvalutionPage />,
+  },
+]);


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #43 

## 🌱 주요 변경 사항

- 업로드 페이지 퍼블리싱 작업 진행했습니다. 완성된 디자인이 없어 피그마에 있는 디자인 대로 구현했습니다.
- 업로드 컴포넌트 스타일 적용했습니다.
- 업로드 컴포넌트 기본 기능 구현했습니다. 파일 선택 시 유효한 파일일 경우 바로 react-hook-form의 handleSubmit 함수를 실행합니다. 해당 함수는 추후 업로드 API 호출 기능을 수행할 예정입니다.
- 라우팅 적용했습니다. 현재는
  - 랜딩 페이지 (`/`)
  - 업로드 페이지 (`/upload`)
  - 피드백 페이지 (`/total-evaluation`)
세 가지 경로로 나눠두었습니다.

## 📸 스크린샷 (선택)

<img width="997" alt="스크린샷 2025-02-20 오전 12 46 48" src="https://github.com/user-attachments/assets/d156d021-7c20-4596-b83b-4ced851dcd09" />
<img width="1005" alt="스크린샷 2025-02-20 오전 12 46 13" src="https://github.com/user-attachments/assets/1ce656f6-c324-4abd-8576-5ef1a6a29f2b" />

## 🗣 리뷰어에게 할 말 (선택)

스타일은 임시로 지정한 거라 크게 확인하지 않아도 됩니다!
