### PR TITLE
[#56] - 사이드바 세부 디자인 인터렉션 수정

### DIFF
--- a/src/features/total-evaluation/components/accordion-list/accordion-list.tsx
+++ b/src/features/total-evaluation/components/accordion-list/accordion-list.tsx
@@ -10,6 +10,7 @@ export type SingleSingleAccordionItemType = {
 };
 
 interface AccordionListProps {
+  isSidebarOpen: boolean;
   currentOpenedTrigger: string[];
   currentSelectedContent: string | null;
   sidebarListData: SingleSingleAccordionItemType[];
@@ -19,6 +20,7 @@ interface AccordionListProps {
 }
 
 function AccordionList({
+  isSidebarOpen,
   currentOpenedTrigger,
   currentSelectedContent,
   sidebarListData,
@@ -33,6 +35,7 @@ function AccordionList({
           return (
             <SingleAccordionItem
               key={accordionTrigger}
+              isSidebarOpen={isSidebarOpen}
               accordionTrigger={accordionTrigger}
               accordionContents={accordionContents}
               renderContent={renderContent}

--- a/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
+++ b/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
@@ -74,21 +74,17 @@ export const basicContentEffect = (
     background-color: #e4e4e5;
   }
 
-  ${isCurrentContentSelected &&
-  isSidebarOpen &&
-  css`
-    &::after {
-      position: absolute;
-      top: 0;
-      left: 0;
-      z-index: -1; /* 텍스트 뒤로 보내기 */
-      width: 0;
-      height: 100%;
-      content: '';
-      background-color: lightgray;
-      animation: fill-right 0.3s forwards;
-    }
-  `}
+  &::after {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: -1;
+    width: ${isCurrentContentSelected ? (isSidebarOpen ? '100%' : '0') : '0'};
+    height: 100%;
+    transition: width 0.3s ease;
+    content: '';
+    background-color: lightgray;
+  }
 
   @keyframes fill-right {
     from {

--- a/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
+++ b/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
@@ -51,13 +51,18 @@ export const accordionContent = css`
   }
 `;
 
-export const basicContentEffect = (index: number, isCurrentContentSelected: boolean) => css`
+export const basicContentEffect = (
+  index: number,
+  isCurrentContentSelected: boolean,
+  isSidebarOpen: boolean,
+) => css`
   transform: translateY(3rem);
   opacity: 0;
   animation: fade-in 0.2s forwards;
   animation-delay: ${index * 0.07}s;
 
   ${isCurrentContentSelected &&
+  isSidebarOpen &&
   css`
     &::after {
       position: absolute;

--- a/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
+++ b/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
@@ -14,6 +14,11 @@ export const basicSelectedEffect = (isCurrentTriggerSelected: boolean) => css`
     font-size 0.3s ease-in-out,
     font-weight 0.3s ease-in-out,
     line-height 0.3s ease-in;
+
+  /* Radix의 접근성으로 인한 기본 포커스 스타일 제거 */
+  &:focus {
+    outline: none;
+  }
 `;
 
 export const wrapper = css`

--- a/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
+++ b/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
@@ -65,6 +65,10 @@ export const basicContentEffect = (
   animation: fade-in 0.2s forwards;
   animation-delay: ${index * 0.07}s;
 
+  &:hover {
+    background-color: #e4e4e5;
+  }
+
   ${isCurrentContentSelected &&
   isSidebarOpen &&
   css`

--- a/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
+++ b/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
@@ -16,11 +16,15 @@ export const basicSelectedEffect = (isCurrentTriggerSelected: boolean) => css`
     line-height 0.3s ease-in;
 `;
 
+export const wrapper = css`
+  display: flex;
+  flex-direction: column;
+  margin-top: 1.4rem;
+  border-left: 0.2rem solid lightgray;
+  padding-left: 1rem;
+`;
 export const accordionContent = css`
   overflow: hidden;
-  margin-top: 1.4rem;
-  padding-left: 1.7rem;
-  border-left: 0.2rem solid lightgray;
 
   &[data-state='open'] {
     animation: slide-down 300ms ease-out;

--- a/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
+++ b/src/features/total-evaluation/components/accordion-list/single-accordion-item.styles.ts
@@ -6,7 +6,7 @@ export const container = css`
   line-height: 1.68rem;
 `;
 
-export const selectedEffect = (isCurrentTriggerSelected: boolean) => css`
+export const basicSelectedEffect = (isCurrentTriggerSelected: boolean) => css`
   font-size: ${isCurrentTriggerSelected && '1.6rem'};
   font-weight: ${isCurrentTriggerSelected && 'bolder'};
   line-height: ${isCurrentTriggerSelected && '1.92rem'};

--- a/src/features/total-evaluation/components/accordion-list/single-accordion-item.tsx
+++ b/src/features/total-evaluation/components/accordion-list/single-accordion-item.tsx
@@ -34,21 +34,23 @@ function SingleAccordionItem({
       </Accordion.Header>
 
       <Accordion.Content css={styles.accordionContent}>
-        {accordionContents.map(
-          (content, index) =>
-            typeof renderContent === 'function' && (
-              <div
-                css={styles.basicContentEffect(
-                  index,
-                  currentSelectedContent === content,
-                  isSidebarOpen,
-                )}
-                key={content}
-              >
-                {renderContent(content)}
-              </div>
-            ),
-        )}
+        <div css={styles.wrapper}>
+          {accordionContents.map(
+            (content, index) =>
+              typeof renderContent === 'function' && (
+                <div
+                  css={styles.basicContentEffect(
+                    index,
+                    currentSelectedContent === content,
+                    isSidebarOpen,
+                  )}
+                  key={content}
+                >
+                  {renderContent(content)}
+                </div>
+              ),
+          )}
+        </div>
       </Accordion.Content>
     </Accordion.Item>
   );

--- a/src/features/total-evaluation/components/accordion-list/single-accordion-item.tsx
+++ b/src/features/total-evaluation/components/accordion-list/single-accordion-item.tsx
@@ -5,6 +5,7 @@ import * as Accordion from '@radix-ui/react-accordion';
 import * as styles from './single-accordion-item.styles';
 
 interface SingleAccordionItemProps {
+  isSidebarOpen: boolean;
   accordionTrigger: string;
   accordionContents: string[];
   currentOpenedTrigger: string[];
@@ -14,6 +15,7 @@ interface SingleAccordionItemProps {
 }
 
 function SingleAccordionItem({
+  isSidebarOpen,
   accordionTrigger,
   accordionContents,
   renderContent,
@@ -36,7 +38,11 @@ function SingleAccordionItem({
           (content, index) =>
             typeof renderContent === 'function' && (
               <div
-                css={styles.basicContentEffect(index, currentSelectedContent === content)}
+                css={styles.basicContentEffect(
+                  index,
+                  currentSelectedContent === content,
+                  isSidebarOpen,
+                )}
                 key={content}
               >
                 {renderContent(content)}

--- a/src/features/total-evaluation/components/accordion-list/single-accordion-item.tsx
+++ b/src/features/total-evaluation/components/accordion-list/single-accordion-item.tsx
@@ -26,7 +26,7 @@ function SingleAccordionItem({
   return (
     <Accordion.Item key={accordionTrigger} value={accordionTrigger} css={styles.container}>
       <Accordion.Header>
-        <Accordion.Trigger css={styles.selectedEffect(isCurrentTriggerSelected)} asChild>
+        <Accordion.Trigger css={styles.basicSelectedEffect(isCurrentTriggerSelected)} asChild>
           {typeof renderTrigger === 'function' && renderTrigger(accordionTrigger)}
         </Accordion.Trigger>
       </Accordion.Header>

--- a/src/features/total-evaluation/components/custom-buttons/sidebar-close-button.tsx
+++ b/src/features/total-evaluation/components/custom-buttons/sidebar-close-button.tsx
@@ -1,0 +1,15 @@
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+import { MdOutlineKeyboardDoubleArrowRight } from 'react-icons/md';
+
+import { BaseButton } from '@/common/components/base-button/base-button';
+
+const SidebarCloseButton = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
+  (props, ref) => (
+    <BaseButton {...props} ref={ref}>
+      <MdOutlineKeyboardDoubleArrowRight size={24} />
+    </BaseButton>
+  ),
+);
+SidebarCloseButton.displayName = 'SidebarCloseButton';
+
+export { SidebarCloseButton };

--- a/src/features/total-evaluation/components/custom-buttons/sidebar-open-button.tsx
+++ b/src/features/total-evaluation/components/custom-buttons/sidebar-open-button.tsx
@@ -1,0 +1,15 @@
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+import { MdOutlineKeyboardDoubleArrowLeft } from 'react-icons/md';
+
+import { BaseButton } from '@/common/components/base-button/base-button';
+
+const SidebarOpenButton = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
+  (props, ref) => (
+    <BaseButton {...props} ref={ref}>
+      <MdOutlineKeyboardDoubleArrowLeft size={24} />
+    </BaseButton>
+  ),
+);
+SidebarOpenButton.displayName = 'SidebarOpenButton';
+
+export { SidebarOpenButton };

--- a/src/features/total-evaluation/components/custom-buttons/single-content-button.styles.ts
+++ b/src/features/total-evaluation/components/custom-buttons/single-content-button.styles.ts
@@ -5,10 +5,10 @@ export const singleContentButton = css`
   justify-content: flex-start;
   width: 100%;
   height: 100%;
-  padding-top: 0.7rem;
-  padding-bottom: 0.7rem;
-  padding-left: 1rem;
+  padding-top: 0.6rem;
+  padding-bottom: 0.6rem;
+  padding-left: 0.5rem;
   border: none;
   background-color: transparent;
-  border-radius: 0.5rem;
+  border-radius: 0.7rem;
 `;

--- a/src/features/total-evaluation/components/feedback-sidebar/feedback-sidebar.tsx
+++ b/src/features/total-evaluation/components/feedback-sidebar/feedback-sidebar.tsx
@@ -1,9 +1,5 @@
 import { useState } from 'react';
 import { FaPlus } from 'react-icons/fa6';
-import {
-  MdOutlineKeyboardDoubleArrowLeft,
-  MdOutlineKeyboardDoubleArrowRight,
-} from 'react-icons/md';
 
 import AccordionList from '@/features/total-evaluation/components/accordion-list/accordion-list';
 import { AccordionTriggerButton } from '@/features/total-evaluation/components/custom-buttons/accordion-trigger-button';
@@ -11,6 +7,9 @@ import { SingleContentButton } from '@/features/total-evaluation/components/cust
 import LeftSlidePanelToggle from '@/features/total-evaluation/components/left-slide-panel-toggle/left-slide-panel-toggle';
 import { sidebarList } from '@/features/total-evaluation/service/data';
 import { adaptToAccordionFormat } from '@/features/total-evaluation/utils/adapt-accordion-format';
+
+import { SidebarCloseButton } from '../custom-buttons/sidebar-close-button';
+import { SidebarOpenButton } from '../custom-buttons/sidebar-open-button';
 
 import * as styles from './feedback-sidebar.styles';
 
@@ -46,11 +45,7 @@ function FeedbackSidebar() {
       setIsSidebarOpen={setIsSidebarOpen}
       additionalButton={<FaPlus />}
       triggerSidebar={(isSidebarOpen) => {
-        return isSidebarOpen ? (
-          <MdOutlineKeyboardDoubleArrowLeft size={24} />
-        ) : (
-          <MdOutlineKeyboardDoubleArrowRight size={24} />
-        );
+        return isSidebarOpen ? <SidebarOpenButton /> : <SidebarCloseButton />;
       }}
       title={<p css={styles.sidebarTitle}>포트폴리오 종합 평가</p>}
     >

--- a/src/features/total-evaluation/components/feedback-sidebar/feedback-sidebar.tsx
+++ b/src/features/total-evaluation/components/feedback-sidebar/feedback-sidebar.tsx
@@ -44,7 +44,7 @@ function FeedbackSidebar() {
     <LeftSlidePanelToggle
       isSidebarOpen={isSidebarOpen}
       setIsSidebarOpen={setIsSidebarOpen}
-      newTaskButton={<FaPlus />}
+      additionalButton={<FaPlus />}
       triggerSidebar={(isSidebarOpen) => {
         return isSidebarOpen ? (
           <MdOutlineKeyboardDoubleArrowLeft size={24} />

--- a/src/features/total-evaluation/components/feedback-sidebar/feedback-sidebar.tsx
+++ b/src/features/total-evaluation/components/feedback-sidebar/feedback-sidebar.tsx
@@ -55,6 +55,7 @@ function FeedbackSidebar() {
       title={<p css={styles.sidebarTitle}>포트폴리오 종합 평가</p>}
     >
       <AccordionList
+        isSidebarOpen={isSidebarOpen}
         currentOpenedTrigger={currentOpenedTrigger}
         currentSelectedContent={currentSelectedContent}
         sidebarListData={adaptedSidebarListData}

--- a/src/features/total-evaluation/components/left-slide-panel-toggle/left-slide-panel-toggle.styles.ts
+++ b/src/features/total-evaluation/components/left-slide-panel-toggle/left-slide-panel-toggle.styles.ts
@@ -33,7 +33,7 @@ export const container = (isSidebarOpen: boolean) => css`
     ? `translateX(0)`
     : `translateX(-${SIDEBAR_WIDTH - SIDEBAR_CLOSED_WIDTH}rem)`};
   transition: transform 0.3s ease;
-  background-color: #f6f7f9;
+  background-color: ${isSidebarOpen ? '#f6f7f9' : 'transparent'};
 `;
 
 export const title = css`

--- a/src/features/total-evaluation/components/left-slide-panel-toggle/left-slide-panel-toggle.tsx
+++ b/src/features/total-evaluation/components/left-slide-panel-toggle/left-slide-panel-toggle.tsx
@@ -25,7 +25,7 @@ function LeftSlidePanelToggle({
     <Dialog.Root modal={false} open={isSidebarOpen} onOpenChange={setIsSidebarOpen}>
       <div css={styles.container(isSidebarOpen)}>
         <div css={styles.sidebarTopSection}>
-          CRITX
+          CRITIX
           <div css={styles.controlButtons}>
             {newTaskButton}
             <Dialog.Trigger asChild>{triggerSidebar(isSidebarOpen)}</Dialog.Trigger>

--- a/src/features/total-evaluation/components/left-slide-panel-toggle/left-slide-panel-toggle.tsx
+++ b/src/features/total-evaluation/components/left-slide-panel-toggle/left-slide-panel-toggle.tsx
@@ -9,7 +9,7 @@ interface SidebarProps {
   isSidebarOpen: boolean;
   setIsSidebarOpen: Dispatch<React.SetStateAction<boolean>>;
   triggerSidebar: (isSidebarOpen: boolean) => ReactNode;
-  newTaskButton?: ReactNode;
+  additionalButton?: ReactNode;
   title: ReactNode;
 }
 
@@ -18,7 +18,7 @@ function LeftSlidePanelToggle({
   isSidebarOpen,
   setIsSidebarOpen,
   triggerSidebar,
-  newTaskButton,
+  additionalButton,
   title,
 }: SidebarProps) {
   return (
@@ -27,7 +27,7 @@ function LeftSlidePanelToggle({
         <div css={styles.sidebarTopSection}>
           CRITIX
           <div css={styles.controlButtons}>
-            {newTaskButton}
+            {additionalButton}
             <Dialog.Trigger asChild>{triggerSidebar(isSidebarOpen)}</Dialog.Trigger>
           </div>
         </div>


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #56 

## 🌱 주요 변경 사항

- 로고 오타 수정
  CRITX -> CRITIX
- 사이드바가 닫힐 때 사이드바 색상 투명으로 변경
- 메뉴 hover색상 추가
- radix의 trigger 사용으로 안한 ref값 전달에러 현상 수정
  > radix primitives Dialog의 trigger에 asChild속성을 사용할 때, ref값을 전달받기 위해 넘겨주기 위해 별도의 forwardRef컴포넌트로 래핑합니다

- 사이드바가 닫힐 때, 동적 높이 계산 오류로 인해 깜빡이는 현상 제거
   > Radix는 아코디언의 열고 닫힘 애니메이션을 별도로 제공합니다. 이때, 내부적으로 height 값을 계산 및 조작하여 구현하게 되는데, 해당 요소들에 직접적으로 display: flex를 적용하면 이 height 계산에 영향을 미칠 수 있습니다. 그러므로 별도의 래핑 요소를 추가합니다
   >  ![image](https://github.com/user-attachments/assets/9f7bbe9a-9a13-4176-8ffb-12966722c8e8)


- 사이드바가 닫힐 때, 기존에 선택된 메뉴의 배경색이 일부 보이는 현상 제거
- 접근성에 따른 outline 현상 수정
