### PR TITLE
[#52] - 업로드 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-progress": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.2",
+    "@tanstack/react-query": "^5.66.7",
+    "axios": "^1.7.9",
     "dompurify": "^3.2.4",
     "path": "^0.12.7",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.1.2(@types/react@18.3.18)(react@18.3.1)
+      '@tanstack/react-query':
+        specifier: ^5.66.7
+        version: 5.66.7(react@18.3.1)
+      axios:
+        specifier: ^1.7.9
+        version: 1.7.9
       dompurify:
         specifier: ^3.2.4
         version: 3.2.4
@@ -1794,6 +1800,14 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
+  '@tanstack/query-core@5.66.4':
+    resolution: {integrity: sha512-skM/gzNX4shPkqmdTCSoHtJAPMTtmIJNS0hE+xwTTUVYwezArCT34NMermABmBVUg5Ls5aiUXEDXfqwR1oVkcA==}
+
+  '@tanstack/react-query@5.66.7':
+    resolution: {integrity: sha512-qd3q/tUpF2K1xItfPZddk1k/8pSXnovg41XyCqJgPoyYEirMBtB0sVEVVQ/CsAOngzgWtBPXimVf4q4kM9uO6A==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
@@ -2139,6 +2153,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
 
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
@@ -2825,6 +2842,15 @@ packages:
 
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
+
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   for-each@0.3.4:
     resolution: {integrity: sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==}
@@ -3736,6 +3762,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
@@ -6408,6 +6437,13 @@ snapshots:
       - supports-color
       - typescript
 
+  '@tanstack/query-core@5.66.4': {}
+
+  '@tanstack/react-query@5.66.7(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.66.4
+      react: 18.3.1
+
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -6843,6 +6879,14 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.0.0
+
+  axios@1.7.9:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.1
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   b4a@1.6.7: {}
 
@@ -7646,6 +7690,8 @@ snapshots:
       hookified: 1.7.0
 
   flatted@3.3.2: {}
+
+  follow-redirects@1.15.9: {}
 
   for-each@0.3.4:
     dependencies:
@@ -8543,6 +8589,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@1.1.0: {}
 
   pump@3.0.2:
     dependencies:

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,15 +2,20 @@ import { RouterProvider } from 'react-router';
 
 import { globalStyles } from '@assets/styles/global-styles';
 import { Global } from '@emotion/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { router } from './route';
 
+const queryClient = new QueryClient();
+
 function App() {
   return (
-    <div>
-      <Global styles={globalStyles} />
-      <RouterProvider router={router} />
-    </div>
+    <QueryClientProvider client={queryClient}>
+      <div>
+        <Global styles={globalStyles} />
+        <RouterProvider router={router} />
+      </div>
+    </QueryClientProvider>
   );
 }
 

--- a/src/common/services/service-config.ts
+++ b/src/common/services/service-config.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export const axiosInstance = axios.create({
+  baseURL: 'http://211.188.53.83:8080',
+});

--- a/src/features/upload/components/file-upload/file-upload.tsx
+++ b/src/features/upload/components/file-upload/file-upload.tsx
@@ -1,12 +1,5 @@
-import { useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
-import {
-  Controller,
-  FieldValues,
-  SubmitErrorHandler,
-  SubmitHandler,
-  useForm,
-} from 'react-hook-form';
+import { Controller, FieldValues, SubmitErrorHandler, useForm } from 'react-hook-form';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -24,40 +17,39 @@ const schema = z.object({
     .refine((file) => file?.type?.includes('pdf'), 'PDF 파일을 업로드해주세요.'),
 });
 
-export default function FileUpload({ ...props }) {
+interface FileUploadProps {
+  onSubmit: (data: FieldValues) => unknown;
+}
+
+// 파일 업로드용 컴포넌트
+export default function FileUpload({ onSubmit }: FileUploadProps) {
   const {
     handleSubmit,
     control,
-    watch,
     formState: { errors },
   } = useForm({
     resolver: zodResolver(schema),
     mode: 'onChange',
   });
 
-  const onSubmit: SubmitHandler<FieldValues> = (data) => {
-    // TODO: PDF 업로드 API 호출
-    console.log(data);
-  };
-
   const onSubmitError: SubmitErrorHandler<FieldValues> = (errors) => {
     console.log('errors', errors);
   };
 
-  const file = watch('file');
-
-  useEffect(() => {
-    if (!file) return;
-
-    handleSubmit(onSubmit, onSubmitError)();
-  }, [file, handleSubmit]);
-
   return (
-    <form css={styles.form}>
+    <form css={styles.form} onSubmit={handleSubmit(onSubmit, onSubmitError)}>
       <Controller
         name="file"
         control={control}
-        render={({ field }) => <Dropzone {...props} onChange={field.onChange} />}
+        render={({ field }) => (
+          <Dropzone
+            onChange={(files) => {
+              field.onChange(files);
+
+              handleSubmit(onSubmit, onSubmitError)();
+            }}
+          />
+        )}
       />
       {errors.file && <div css={styles.errorText}>{errors.file.message?.toString()}</div>}
     </form>

--- a/src/features/upload/components/portfolio-upload/portfolio-upload.tsx
+++ b/src/features/upload/components/portfolio-upload/portfolio-upload.tsx
@@ -1,0 +1,29 @@
+import { usePostPortfolioMutation } from '../../services/mutations';
+import FileUpload from '../file-upload/file-upload';
+
+export default function PortfolioUpload() {
+  const { mutateAsync: postPortfolio } = usePostPortfolioMutation();
+
+  return (
+    <FileUpload
+      onSubmit={async ({ file }) => {
+        try {
+          const formData = new FormData();
+          formData.append('file', file);
+
+          const res = await postPortfolio({
+            file,
+          });
+
+          if (res.url) {
+            // TODO: 업로드 성공 시 액션
+            console.log('success', res);
+          }
+        } catch (error) {
+          // TODO: 업로드 실패 시 액션
+          console.log('error', error);
+        }
+      }}
+    />
+  );
+}

--- a/src/features/upload/services/mutations.ts
+++ b/src/features/upload/services/mutations.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { postPortfolio } from './post-portfolio';
+import { PortfolioRequest } from '../types/portfolio-types';
+
+export const usePostPortfolioMutation = () => {
+  return useMutation({
+    mutationKey: ['postPortfolio'],
+    mutationFn: async ({ file }: PortfolioRequest) => {
+      const data = await postPortfolio({ file });
+
+      return data;
+    },
+  });
+};

--- a/src/features/upload/services/post-portfolio.ts
+++ b/src/features/upload/services/post-portfolio.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from '@/common/services/service-config';
+
+import { PortfolioRequest, PortfolioResponse } from '../types/portfolio-types';
+
+export const postPortfolio = async ({ file }: PortfolioRequest) => {
+  const { data } = await axiosInstance.post<PortfolioResponse>(
+    '/api/v1/files/portfolio',
+    {
+      file,
+    },
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+  );
+
+  return data;
+};

--- a/src/features/upload/stories/file-upload.stories.tsx
+++ b/src/features/upload/stories/file-upload.stories.tsx
@@ -5,12 +5,15 @@ import FileUpload from '@/features/upload/components/file-upload/file-upload';
 const meta = {
   title: 'Components/FileUpload',
   component: FileUpload,
-  argTypes: {
-    maxFiles: { control: 'number', description: '업로드 가능한 파일 개수' },
-  },
 } satisfies Meta<typeof FileUpload>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    onSubmit: () => {
+      console.log('submitted');
+    },
+  },
+};

--- a/src/features/upload/types/portfolio-types.ts
+++ b/src/features/upload/types/portfolio-types.ts
@@ -1,0 +1,9 @@
+export type PortfolioRequest = {
+  file: File;
+};
+
+export type PortfolioResponse = {
+  id: string;
+  logicalName: string;
+  url: string;
+};

--- a/src/features/upload/upload-page.tsx
+++ b/src/features/upload/upload-page.tsx
@@ -1,4 +1,4 @@
-import FileUpload from '@/features/upload/components/file-upload/file-upload';
+import PortfolioUpload from './components/portfolio-upload/portfolio-upload';
 
 import * as styles from './upload-page.styles';
 
@@ -7,7 +7,7 @@ export default function UploadPage() {
     <div css={styles.container}>
       <div css={styles.logo}>Logo</div>
       <h1 css={styles.title}>포트폴리오를 업그레이드 해볼까요?</h1>
-      <FileUpload />
+      <PortfolioUpload />
     </div>
   );
 }


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #52 

## 🌱 주요 변경 사항

- axios, @tanstack/react-query 설치했습니다.
- 공통 axios 인스턴스 추가 및 queryClient 추가했습니다.
- 포트폴리오 API 연동했습니다.
  - postPortfolio API 호출 함수, useMutation 호출용 훅으로 나눠 구현했습니다. 개인적으로 이렇게 나누는 게 편해서 이렇게 작업했는데 이 부분 피드백 주시면 감사하겠습니다!
- FileUpload 컴포넌트를 래핑한 PortfolioUpload 컴포넌트 내부에서 API를 호출합니다.
  - 추후 FileUpload 컴포넌트를 범용 컴포넌트로 다시 작성하고, 업로드가 필요한 영역에서 래퍼 컴포넌트를 작성하려고 합니다.

## 🗣 리뷰어에게 할 말 (선택)

- form 내부 input 요소의 onChange 핸들러 내부에서 handleSubmit 함수를 실행하니까 깔끔하게 동작합니다..! 
- 이후 FileUpload 공통 컴포넌트로 추출 작업 및 업로드 페이지 변경된 스타일 적용 작업 예정입니다!
