### PR TITLE
[#59] - 기본 폰트 및 타이포그래피 설정

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,20 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <link
-      rel="apple-touch-icon"
-      href="/apple-touch-icon-180x180.png"
-      sizes="180x180"
-    />
-    <link rel="manifest" href="manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" sizes="180x180" />
+    <link rel="manifest" href="manifest.json" />
+
+    <link
+      rel="stylesheet"
+      as="style"
+      crossorigin
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css"
+    />
+
     <title>onepiece-fe</title>
   </head>
   <body>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,9 +1,10 @@
 import { RouterProvider } from 'react-router';
 
 import { globalStyles } from '@assets/styles/global-styles';
-import { Global } from '@emotion/react';
+import { Global, ThemeProvider } from '@emotion/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+import { theme } from './assets/styles/theme';
 import { router } from './route';
 
 const queryClient = new QueryClient();
@@ -11,10 +12,10 @@ const queryClient = new QueryClient();
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <div>
+      <ThemeProvider theme={theme}>
         <Global styles={globalStyles} />
         <RouterProvider router={router} />
-      </div>
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }

--- a/src/assets/styles/emotion.d.ts
+++ b/src/assets/styles/emotion.d.ts
@@ -1,0 +1,9 @@
+import '@emotion/react';
+
+import { FontsTypes } from './fonts';
+
+declare module '@emotion/react' {
+  export interface Theme {
+    fonts: FontsTypes;
+  }
+}

--- a/src/assets/styles/fonts.ts
+++ b/src/assets/styles/fonts.ts
@@ -1,0 +1,41 @@
+import { css } from '@emotion/react';
+
+const generateTypography = (
+  size: number,
+  weight: number,
+  lineHeight: number,
+  letterSpacing?: number,
+) => css`
+  font-style: normal;
+  color: #000;
+  font-size: ${size}rem;
+  font-weight: ${weight};
+  line-height: ${lineHeight}%;
+  ${letterSpacing && `letter-spacing: ${letterSpacing}rem;`}
+`;
+
+export const fonts = {
+  HEADLINE: {
+    HEAD1: generateTypography(3.2, 700, 140, 0.032),
+    HEAD2: generateTypography(2.6, 700, 150, 0.026),
+    HEAD3: generateTypography(2.4, 700, 150, 0.024),
+    HEAD4: generateTypography(2.2, 600, 150, 0.022),
+    HEAD5: generateTypography(2, 700, 140, 0.02),
+  },
+
+  BODY: {
+    BODY1_B: generateTypography(1.8, 700, 145, -0.018),
+    BODY1_SB: generateTypography(1.8, 600, 145, -0.018),
+    BODY2_SB: generateTypography(1.6, 500, 170, 0.016),
+    BODY2_M: generateTypography(1.6, 500, 170, 0.016),
+    BODY2_R: generateTypography(1.6, 400, 150, 0.016),
+    BODY3_SB: generateTypography(1.5, 500, 170, 0.015),
+  },
+
+  CAPTION: {
+    CAPTION1_SB: generateTypography(1.4, 600, 150),
+    CAPTION1_M: generateTypography(1.4, 500, 150, -0.014),
+  },
+} as const;
+
+export type FontsTypes = typeof fonts;

--- a/src/assets/styles/global-styles.ts
+++ b/src/assets/styles/global-styles.ts
@@ -4,9 +4,9 @@ export const globalStyles = css`
   *,
   *::before,
   *::after {
-    box-sizing: border-box;
     margin: 0;
     padding: 0;
+    box-sizing: border-box;
   }
 
   body {
@@ -177,8 +177,17 @@ export const globalStyles = css`
 
   html {
     font-size: 62.5%; /* 1rem = 10px */
-    -moz-text-size-adjust: none;
-    -webkit-text-size-adjust: none;
     text-size-adjust: none;
+    font-family:
+      Pretendard,
+      -apple-system,
+      BlinkMacSystemFont,
+      system-ui,
+      Roboto,
+      'Helvetica Neue',
+      'Segoe UI',
+      'Apple SD Gothic Neo',
+      'Malgun Gothic',
+      sans-serif;
   }
 `;

--- a/src/assets/styles/theme.ts
+++ b/src/assets/styles/theme.ts
@@ -1,0 +1,9 @@
+import { Theme } from '@emotion/react';
+
+import { fonts } from './fonts';
+
+export const theme: Theme = {
+  fonts,
+};
+
+export type ThemeType = typeof theme;

--- a/src/common/utils/with-theme.ts
+++ b/src/common/utils/with-theme.ts
@@ -1,0 +1,53 @@
+import { css, Theme, useTheme } from '@emotion/react';
+
+/**
+ * theme을 자동으로 주입하는 유틸 함수
+ *
+ * Emotion의 css 리터럴 템플릿에서는 theme 타입 추론이 되지 않으므로,
+ * 해당 함수를 통해 theme을 전달하여 타입을 올바르게 추론할 수 있도록 함.
+ */
+export const withTheme =
+  <T extends unknown[]>(styleFn: (theme: Theme, ...args: T) => ReturnType<typeof css>) =>
+  (...args: T) => {
+    const theme = useTheme();
+    return styleFn(theme, ...args);
+  };
+
+/**
+ * 사용법
+ *
+ * ❕ 기본 사용
+ * `withTheme`을 사용하여 스타일 함수에서 theme을 자동으로 사용할 수 있습니다.
+ *
+ * export const orderListText = withTheme((theme) => css`
+ *   ${theme.fonts.BODY.BODY1_B};
+ *   color: black;
+ * `);
+ *
+ * <ol css={styles.orderListText}></ol>
+ *
+ * --------------------------------
+ *
+ * ❕ 매개변수 전달
+ * 추가적인 스타일 값을 함께 전달할 수도 있습니다.
+ *
+ * export const orderListText = withTheme((theme, color: string) => css`
+ *   ${theme.fonts.BODY.BODY1_B};
+ *   color: ${color};
+ * `);
+ *
+ * <ol css={styles.orderListText('#000')}></ol>
+ *
+ * --------------------------------
+ *
+ * ❕ 여러 개의 매개변수 전달
+ * 여러 개의 값을 전달해야 할 경우, 추가 인자를 사용할 수 있습니다.
+ *
+ * export const customBox = withTheme((theme, bgColor: string, padding: string) => css`
+ *   background-color: ${bgColor};
+ *   padding: ${padding};
+ *   border-radius: ${theme.borderRadius};
+ * `);
+ *
+ * <div css={styles.customBox('blue', '1rem')}></div>
+ */

--- a/src/common/utils/with-theme.ts
+++ b/src/common/utils/with-theme.ts
@@ -3,7 +3,7 @@ import { css, Theme, useTheme } from '@emotion/react';
 /**
  * theme을 자동으로 주입하는 유틸 함수
  *
- * Emotion의 css 리터럴 템플릿에서는 theme 타입 추론이 되지 않으므로,
+ * Emotion의 css 태그 템플릿에서는 theme 타입 추론이 되지 않으므로,
  * 해당 함수를 통해 theme을 전달하여 타입을 올바르게 추론할 수 있도록 함.
  */
 export const withTheme =


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #59

## 🌱 주요 변경 사항
- 기본 폰트 및 타이포그래피 설정  
- Emotion css 리터럴에서 theme을 자동으로 주입하는 유틸 함수 추가  

  `with-theme` 파일의 사용법을 참고하여, **css 태그 템플릿을 `withTheme` 함수로 감싸서 사용해 주세요.**  
  이를 통해 **theme 타입을 올바르게 추론할 수 있습니다.**
