### PR TITLE
[#68] - 디자인 시스템 (Text Input) 구현

### DIFF
--- a/src/common/components/text-input/text-input-status.ts
+++ b/src/common/components/text-input/text-input-status.ts
@@ -1,0 +1,21 @@
+import { css } from '@emotion/react';
+
+import { TextInputStatusType } from './text-input';
+
+/** 각 상태별 field와 message 영역 스타일 정의 */
+export const textInputStatus: Record<
+  TextInputStatusType,
+  { field: ReturnType<typeof css>; message: ReturnType<typeof css> }
+> = {
+  error: {
+    field: css`
+      border: 0.072rem solid #ff909066 !important;
+      background-color: rgb(255 255 255 / 5%);
+      box-shadow: none;
+    `,
+    message: css`
+      color: #ff9090;
+      padding-left: 1.382rem;
+    `,
+  },
+};

--- a/src/common/components/text-input/text-input.styles.ts
+++ b/src/common/components/text-input/text-input.styles.ts
@@ -1,0 +1,64 @@
+import { css } from '@emotion/react';
+
+import { withTheme } from '@/common/utils/with-theme';
+
+import { TextInputStatusType } from './text-input';
+import { textInputStatus } from './text-input-status';
+
+//TODO: theme 적용되면 반영
+
+interface TextInputProps {
+  width?: number;
+  height?: number;
+  status?: TextInputStatusType;
+}
+
+export const textInputWrapper = withTheme(
+  () => css`
+    display: flex;
+    flex-direction: column;
+    gap: 0.576rem;
+  `,
+);
+
+export const textInput = ({ width, height, status }: TextInputProps) => css`
+  width: ${width ? `${width}rem` : '100%'};
+  height: ${height ? `${height}rem` : 'auto'};
+  border-radius: 1.3rem;
+  padding: 1.3rem 2rem;
+  color: #fff;
+  font-size: 1.1515rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  resize: none;
+  background-color: rgb(255 255 255 / 5%);
+  box-shadow: 0 0 0.5038rem 0 rgb(255 255 255 / 25%);
+
+  &:hover {
+    background-color: rgb(255 255 255 / 10%);
+    box-shadow: 0 0 0.5038rem 0 rgb(255 255 255 / 35%);
+  }
+
+  &:focus {
+    outline: none;
+    border: 0.072rem solid rgb(255 255 255 / 30%);
+  }
+
+  &[data-has-value='true'] {
+    box-shadow: 0 0 0.5038rem 0 rgb(255 255 255 / 35%);
+  }
+
+  &::placeholder {
+    color: #b1b1b1;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 1.382rem;
+  }
+
+  ${status && textInputStatus[status]?.field}
+`;
+
+export const statusMessage = (status?: TextInputStatusType) => css`
+  ${status && textInputStatus[status]?.message}
+`;

--- a/src/common/components/text-input/text-input.tsx
+++ b/src/common/components/text-input/text-input.tsx
@@ -1,0 +1,47 @@
+import * as styles from './text-input.styles';
+
+/** text-input 컴포넌트의 상태 (ex. error, success, warning, ..) */
+export type TextInputStatusType = 'error';
+
+interface TextInputProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  // 기본 값
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+
+  // UI 관련
+  placeholder?: string;
+  width?: number;
+  height?: number;
+
+  // 상태 관련
+  status?: TextInputStatusType;
+  message?: string;
+}
+
+export default function TextInput({
+  value,
+  onChange,
+
+  placeholder,
+  width,
+  height,
+
+  status,
+  message,
+
+  ...props
+}: TextInputProps) {
+  return (
+    <div css={styles.textInputWrapper}>
+      <textarea
+        css={styles.textInput({ width, height, status })}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        data-has-value={value && value?.length > 0}
+        {...props}
+      />
+      {status && message && <p css={styles.statusMessage(status)}>{message}</p>}
+    </div>
+  );
+}

--- a/src/common/components/text-input/text-input.tsx
+++ b/src/common/components/text-input/text-input.tsx
@@ -1,12 +1,14 @@
+import { ChangeEvent, TextareaHTMLAttributes } from 'react';
+
 import * as styles from './text-input.styles';
 
 /** text-input 컴포넌트의 상태 (ex. error, success, warning, ..) */
 export type TextInputStatusType = 'error';
 
-interface TextInputProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+interface TextInputProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   // 기본 값
   value?: string;
-  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onChange?: (e: ChangeEvent<HTMLTextAreaElement>) => void;
 
   // UI 관련
   placeholder?: string;

--- a/src/common/stories/text-input.stories.tsx
+++ b/src/common/stories/text-input.stories.tsx
@@ -1,0 +1,63 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import TextInput from '../components/text-input/text-input';
+
+const meta: Meta<typeof TextInput> = {
+  title: 'Components/TextInput',
+  component: TextInput,
+  argTypes: {
+    width: {
+      description: 'TextInput의 너비를 결정합니다. (default: 100%)',
+      control: { type: 'number' },
+    },
+    height: {
+      description: 'TextInput의 높이를 결정합니다. (default: auto)',
+      control: { type: 'number' },
+    },
+    placeholder: {
+      description: 'TextInput의 placeholder를 설정합니다.',
+      control: { type: 'text' },
+    },
+    value: {
+      description: 'TextInput의 value를 설정합니다. (value가 있는 경우 data-has-value 속성이 true)',
+      control: { type: 'text' },
+    },
+    status: {
+      description: 'TextInput의 상태를 결정합니다.',
+      control: 'radio',
+      options: ['error'],
+    },
+    message: {
+      description: 'TextInput의 상태에 따른 문구를 설정합니다.',
+      control: 'text',
+    },
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextInput>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'placeholder',
+  },
+};
+
+export const Typed: Story = {
+  args: {
+    placeholder: 'placeholder',
+    value: 'typed',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    placeholder: 'placeholder',
+    status: 'error',
+    message: 'error message',
+  },
+};


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #68 

## 🌱 주요 변경 사항
- 디자인 시스템 내 TextInput 구현

## 📸 스크린샷 (선택)
<img width="491" alt="image" src="https://github.com/user-attachments/assets/55a72213-2af4-4444-8288-d0557fbb5dee" />

## 🗣 리뷰어에게 할 말 (선택)
현재 피그마 디자인 시스템의 TextInput에 타이포그래피와 색상이 적용되어 있지 않아, 우선은 제공된 디자인 그대로 적용하였습니다. 
추후 디자인 시스템이 확정되면 withTheme을 활용해 theme을 적용할 예정입니다.

또한, 현재는 error 상태만 구현되어 있지만, 확장 가능성을 고려하여 status 타입을 분리해 두었습니다.
이를 통해 success, warning 등의 상태를 추가할 수 있으며, 각 상태에 따른 필드 및 메시지 스타일은 `text-input-status.ts`에서 관리할 수 있습니다.

react-hook-form과 zod를 활용한 유효성 검증 예시는 아래와 같습니다.

![image](https://github.com/user-attachments/assets/69a76a68-88b4-4f48-94c1-a2fb9ab6bf34)

