### PR TITLE
[#65] - 논리적 비약, 가독성 개선 색션 디자인 반영

### DIFF
--- a/src/assets/styles/fonts.ts
+++ b/src/assets/styles/fonts.ts
@@ -16,25 +16,38 @@ const generateTypography = (
 
 export const fonts = {
   HEADLINE: {
-    HEAD1: generateTypography(3.2, 700, 140, 0.032),
-    HEAD2: generateTypography(2.6, 700, 150, 0.026),
-    HEAD3: generateTypography(2.4, 700, 150, 0.024),
-    HEAD4: generateTypography(2.2, 600, 150, 0.022),
-    HEAD5: generateTypography(2, 700, 140, 0.02),
+    HEAD1: generateTypography(3.6, 700, 140, 0.036),
+    HEAD2: generateTypography(3.2, 700, 140, 0.032),
+    HEAD3: generateTypography(2.6, 700, 140, 0.026),
+    HEAD4: generateTypography(2.4, 700, 140, 0.024),
+    HEAD5: generateTypography(2.2, 600, 140, 0.022),
+    HEAD6: generateTypography(2, 700, 140, 0.02),
+  },
+
+  SUBTITLE: {
+    SUB1_SB: generateTypography(2, 600, 140),
+    SUB1_M: generateTypography(2, 500, 140),
+    SUB2_B: generateTypography(1.8, 700, 140),
+    SUB2_SB: generateTypography(1.8, 600, 140),
+    SUB3_B: generateTypography(1.6, 700, 140),
+    SUB3_SB: generateTypography(1.6, 600, 140),
+    SUB4_SB: generateTypography(1.5, 600, 140),
+    SUB5_SB: generateTypography(1.4, 600, 140),
+    SUB5_M: generateTypography(1.4, 500, 140),
   },
 
   BODY: {
-    BODY1_B: generateTypography(1.8, 700, 145, -0.018),
-    BODY1_SB: generateTypography(1.8, 600, 145, -0.018),
-    BODY2_SB: generateTypography(1.6, 500, 170, 0.016),
-    BODY2_M: generateTypography(1.6, 500, 170, 0.016),
-    BODY2_R: generateTypography(1.6, 400, 150, 0.016),
-    BODY3_SB: generateTypography(1.5, 500, 170, 0.015),
+    BODY1_R: generateTypography(1.8, 400, 160, -0.018),
+    BODY2_M: generateTypography(1.6, 500, 170, -0.016),
+    BODY2_R: generateTypography(1.6, 400, 170, -0.016),
+    BODY3_R: generateTypography(1.4, 400, 160, -0.014),
+    BODY4_M: generateTypography(1.3, 500, 150, -0.013),
+    BODY5_M: generateTypography(1.2, 500, 150, -0.012),
   },
 
   CAPTION: {
     CAPTION1_SB: generateTypography(1.4, 600, 150),
-    CAPTION1_M: generateTypography(1.4, 500, 150, -0.014),
+    CAPTION1_M: generateTypography(1.4, 500, 150),
   },
 } as const;
 

--- a/src/features/total-evaluation/components/improvement-section/improvement-section.styles.ts
+++ b/src/features/total-evaluation/components/improvement-section/improvement-section.styles.ts
@@ -5,5 +5,5 @@ export const improvementTextWrapper = css`
   flex-direction: column;
   align-items: flex-start;
   gap: 1.6rem;
-  margin-left: 2.7rem;
+  padding-left: 3.2rem;
 `;

--- a/src/features/total-evaluation/components/improvement-section/improvement-text.styles.ts
+++ b/src/features/total-evaluation/components/improvement-section/improvement-text.styles.ts
@@ -1,39 +1,25 @@
 import { css } from '@emotion/react';
 
+import { withTheme } from '@/common/utils/with-theme';
+
 export const improvementTextWrapper = css`
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.8rem;
-`;
-
-export const label = css`
-  color: #979aa1;
-  font-size: 1.4rem;
-  font-weight: 500;
-  line-height: 2.1rem;
-  letter-spacing: 0.014rem;
-`;
-
-export const improvementTextContent = css`
-  display: flex;
-  gap: 1.2rem;
   align-items: center;
-  line-height: 2.4rem;
-`;
-
-export const colorBlock = (label: string) => css`
-  min-width: 0.2rem;
-  background-color: ${label === '기존문장' ? '#ff6c6c' : '#4caf50'};
-  flex-grow: 1;
+  gap: 2rem;
   align-self: stretch;
 `;
 
-export const text = css`
-  padding-top: 0.3rem;
-  color: #4d5159;
-  font-size: 1.6rem;
-  font-weight: 500;
-  line-height: 2.4rem;
-  letter-spacing: 0.016rem;
-`;
+export const label = (label: string) =>
+  withTheme(
+    (theme) => css`
+      ${theme.fonts.SUBTITLE.SUB3_SB};
+      color: ${label === '기존 문장' ? `${theme.colors.RED[400]}` : `${theme.colors.GREEN[400]}`};
+    `,
+  );
+
+export const text = withTheme(
+  (theme) => css`
+    ${theme.fonts.BODY.BODY2_M};
+    color: ${theme.colors.GRAY[300]};
+  `,
+);

--- a/src/features/total-evaluation/components/improvement-section/improvement-text.tsx
+++ b/src/features/total-evaluation/components/improvement-section/improvement-text.tsx
@@ -8,11 +8,8 @@ interface ImprovementTextProps {
 export default function ImprovementText({ label, improvementText }: ImprovementTextProps) {
   return (
     <div css={styles.improvementTextWrapper}>
-      <span css={styles.label}>{label}</span>
-      <div css={styles.improvementTextContent}>
-        <div css={styles.colorBlock(label)} />
-        <p css={styles.text}>{improvementText}</p>
-      </div>
+      <span css={styles.label(label)}>{label}</span>
+      <p css={styles.text}>{improvementText}</p>
     </div>
   );
 }

--- a/src/features/total-evaluation/components/improvement-title/improvement-title.styles.ts
+++ b/src/features/total-evaluation/components/improvement-title/improvement-title.styles.ts
@@ -1,16 +1,16 @@
 import { css } from '@emotion/react';
 
+import { withTheme } from '@/common/utils/with-theme';
+
 export const improvementTitleWrapper = css`
   display: flex;
   gap: 0.8rem;
   align-items: center;
 `;
 
-export const improvementTitle = css`
-  color: #4a5468;
-  padding-top: 0.3rem;
-  font-size: 2.4rem;
-  font-weight: 700;
-  line-height: 3.6rem;
-  letter-spacing: 0.024rem;
-`;
+export const improvementTitle = withTheme(
+  (theme) => css`
+    ${theme.fonts.HEADLINE.HEAD4};
+    color: ${theme.colors.GRAY[200]};
+  `,
+);

--- a/src/features/total-evaluation/components/improvement-title/improvement-title.tsx
+++ b/src/features/total-evaluation/components/improvement-title/improvement-title.tsx
@@ -1,3 +1,4 @@
+import { colors } from '@assets/styles/colors';
 import Icon from '@common/components/icon/icon';
 
 import * as styles from './improvement-title.styles';
@@ -9,7 +10,7 @@ interface ImprovementTitleProps {
 export default function ImprovementTitle({ improvementTitle }: ImprovementTitleProps) {
   return (
     <div css={styles.improvementTitleWrapper}>
-      <Icon name="checkIcon" />
+      <Icon name="checkIcon" color={colors.GRAY[200]} />
       <span css={styles.improvementTitle}>{improvementTitle}</span>
     </div>
   );

--- a/src/features/total-evaluation/components/logical-leap/logical-error.styles.ts
+++ b/src/features/total-evaluation/components/logical-leap/logical-error.styles.ts
@@ -1,40 +1,41 @@
 import { css } from '@emotion/react';
 
+import { withTheme } from '@/common/utils/with-theme';
+
 export const logicalErrorWrapper = css`
   display: flex;
-  gap: 1.4rem;
+  gap: 1.2rem;
   margin-bottom: 2rem;
 `;
 
-export const redBlock = css`
-  min-width: 0.2rem;
-  background-color: #ff6c6c;
-  align-self: stretch;
-`;
+export const redBlock = withTheme(
+  (theme) => css`
+    min-width: 0.2rem;
+    background-color: ${theme.colors.RED[400]};
+    align-self: stretch;
+  `,
+);
 
 export const logicalErrorTextWrapper = css`
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
-  padding-top: 0.3rem;
 `;
 
-export const label = css`
-  display: inline-flex;
-  align-items: center;
-  color: #ff6c6c;
-  font-size: 1.4rem;
-  font-weight: 500;
-  line-height: 2.1rem;
-  letter-spacing: 0.014rem;
-`;
+export const label = withTheme(
+  (theme) => css`
+    display: inline-flex;
+    align-items: center;
+    ${theme.fonts.SUBTITLE.SUB3_SB};
+    color: ${theme.colors.RED[400]};
+  `,
+);
 
-export const errorItem = css`
-  color: #74767d;
-  font-size: 1.6rem;
-  font-weight: 500;
-  line-height: 2.88rem;
-  list-style: disc;
-  list-style-position: inside;
-  letter-spacing: 0.016rem;
-`;
+export const errorItem = withTheme(
+  (theme) => css`
+    ${theme.fonts.BODY.BODY2_M};
+    color: ${theme.colors.GRAY[300]};
+    list-style: disc;
+    list-style-position: inside;
+  `,
+);

--- a/src/features/total-evaluation/components/logical-leap/logical-error.tsx
+++ b/src/features/total-evaluation/components/logical-leap/logical-error.tsx
@@ -1,3 +1,5 @@
+import { colors } from '@assets/styles/colors';
+
 import Icon from '@/common/components/icon/icon';
 
 import * as styles from './logical-error.styles';
@@ -14,7 +16,7 @@ export default function LogicalError({ label, logicalErrorList }: LogicalErrorPr
       <div css={styles.logicalErrorTextWrapper}>
         <span css={styles.label}>
           {label}
-          <Icon name="pin" />
+          <Icon name="pin" color={colors.RED[400]} />
         </span>
         <ul>
           {logicalErrorList.map((error) => (

--- a/src/features/total-evaluation/components/logical-leap/logical-improvement.styles.ts
+++ b/src/features/total-evaluation/components/logical-leap/logical-improvement.styles.ts
@@ -1,37 +1,38 @@
 import { css } from '@emotion/react';
 
+import { withTheme } from '../../../../common/utils/with-theme';
+
 export const logicalImprovementWrapper = css`
   display: flex;
-  gap: 1.4rem;
+  gap: 1.2rem;
 `;
 
-export const greenBlock = css`
-  min-width: 0.2rem;
-  background-color: #55c467;
-  align-self: stretch;
-`;
+export const greenBlock = withTheme(
+  (theme) => css`
+    min-width: 0.2rem;
+    background-color: ${theme.colors.GREEN[400]};
+    align-self: stretch;
+  `,
+);
 
 export const logicalImprovementTextWrapper = css`
   display: flex;
   flex-direction: column;
-  gap: 0.8rem;
-  padding-top: 0.3rem;
+  gap: 0.5rem;
 `;
 
-export const label = css`
-  display: inline-flex;
-  align-items: center;
-  color: #55c467;
-  font-size: 1.4rem;
-  font-weight: 500;
-  line-height: 2.1rem;
-  letter-spacing: 0.014rem;
-`;
+export const label = withTheme(
+  (theme) => css`
+    display: inline-flex;
+    align-items: center;
+    ${theme.fonts.SUBTITLE.SUB3_SB};
+    color: ${theme.colors.GREEN[400]};
+  `,
+);
 
-export const improvementText = css`
-  color: #000;
-  font-size: 1.6rem;
-  font-weight: 600;
-  line-height: 2.4rem;
-  letter-spacing: 0.016rem;
-`;
+export const improvementText = withTheme(
+  (theme) => css`
+    ${theme.fonts.SUBTITLE.SUB3_SB};
+    color: ${theme.colors.GRAY[300]};
+  `,
+);

--- a/src/features/total-evaluation/components/logical-leap/logical-improvement.tsx
+++ b/src/features/total-evaluation/components/logical-leap/logical-improvement.tsx
@@ -1,3 +1,5 @@
+import { colors } from '@assets/styles/colors';
+
 import Icon from '@/common/components/icon/icon';
 
 import * as styles from './logical-improvement.styles';
@@ -14,7 +16,7 @@ export default function LogicalImprovement({ label, improvementText }: LogicalIm
       <div css={styles.logicalImprovementTextWrapper}>
         <span css={styles.label}>
           {label}
-          <Icon name="pin" color="#55C467" />
+          <Icon name="pin" color={colors.GREEN[400]} />
         </span>
         <p css={styles.improvementText}>{improvementText}</p>
       </div>

--- a/src/features/total-evaluation/components/logical-leap/logical-leap.styles.ts
+++ b/src/features/total-evaluation/components/logical-leap/logical-leap.styles.ts
@@ -1,14 +1,15 @@
 import { css } from '@emotion/react';
 
+import { withTheme } from '@/common/utils/with-theme';
+
 export const logicalLeapWrapper = css`
-  margin-left: 2.7rem;
+  margin-left: 2.4rem;
 `;
 
-export const logicalLeapDescription = css`
-  color: #4e5159;
-  margin-bottom: 1.6rem;
-  font-size: 1.8rem;
-  font-weight: 700;
-  line-height: 2.7rem;
-  letter-spacing: 0.018rem;
-`;
+export const logicalLeapDescription = withTheme(
+  (theme) => css`
+    ${theme.fonts.SUBTITLE.SUB2_B};
+    color: ${theme.colors.GRAY[200]};
+    margin-bottom: 1.6rem;
+  `,
+);

--- a/src/features/total-evaluation/constants/evaluation-constant.ts
+++ b/src/features/total-evaluation/constants/evaluation-constant.ts
@@ -1,8 +1,8 @@
 import { EvaluationCriteria } from '@/features/total-evaluation/types/evaluation-types';
 
 export const IMPROVEMENT_CONSTANT = {
-  originalText: '기존문장',
-  revisedText: '수정',
+  originalText: '기존 문장',
+  revisedText: '수정 문장',
 } as const;
 
 export const LOGICAL_LEAP_CONSTANT = {

--- a/src/features/total-evaluation/total-evaluation-page.styles.ts
+++ b/src/features/total-evaluation/total-evaluation-page.styles.ts
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 
 export const container = css`
+  background-color: #18171d;
   min-height: 100dvh;
   min-width: 100dvw;
   display: flex;

--- a/src/features/total-evaluation/total-evaluation-page.tsx
+++ b/src/features/total-evaluation/total-evaluation-page.tsx
@@ -48,12 +48,12 @@ export default function TotalEvalutionPage() {
           <EvaluationAnalyze analysisItems={solutions} />
         </section>
 
-        <section css={styles.evaluationSection('1rem')}>
+        <section css={styles.evaluationSection('1.6rem')}>
           <ImprovementTitle improvementTitle={improvementData.title} />
           <ImprovementSection improvementData={improvementData} />
         </section>
 
-        <section css={styles.evaluationSection('3.2rem')}>
+        <section css={styles.evaluationSection('2.4rem')}>
           <ImprovementTitle improvementTitle={logicalLeaps.title} />
           <LogicalLeap logicalLeapData={logicalLeaps} />
         </section>


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #65 

## 🌱 주요 변경 사항

1. 디자인 시스템 변경에 따른 Typography 수정
2. 피드백 페이지 배경색 변경 및 gap 수정
3. 문장 가독성 개선 색션 디자인 반영
4. 논리적 비약 섹션 디자인 반영

## 📸 스크린샷 (선택)

<img width="1009" alt="스크린샷 2025-03-01 오후 8 47 34" src="https://github.com/user-attachments/assets/6780cfbe-01f2-496d-bcb2-beacd17c12c5" />


## 🗣 리뷰어에게 할 말 (선택)

total-evaluation-page 부분 style이랑 컴포넌트 코드 약간의 수정이 있습니다.
또한 타이포그래피 수정이 되었으니 변경사항 적용해주시면 감사하겠습니다!!
