### PR TITLE
[#125] - 랜딩페이지 헤더 탭 클릭 시 해당 섹션으로 스크롤 이동

### DIFF
--- a/src/common/components/layout/header-buttons/landing-middle-buttons.tsx
+++ b/src/common/components/layout/header-buttons/landing-middle-buttons.tsx
@@ -6,6 +6,14 @@ import * as styles from './landing-middle-buttons.styles';
 
 function LandingMiddleButtons() {
   const theme = useTheme();
+
+  const scrollToSection = (id: string) => {
+    const element = document.getElementById(id);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
   return (
     <div css={styles.container}>
       <Button
@@ -15,6 +23,7 @@ function LandingMiddleButtons() {
         css={css`
           color: ${theme.colors.GRAY[500]};
         `}
+        onClick={() => scrollToSection('start-section')}
       >
         Start
       </Button>
@@ -25,6 +34,7 @@ function LandingMiddleButtons() {
         css={css`
           color: ${theme.colors.GRAY[500]};
         `}
+        onClick={() => scrollToSection('features-section')}
       >
         Features
       </Button>
@@ -35,6 +45,7 @@ function LandingMiddleButtons() {
         css={css`
           color: ${theme.colors.GRAY[500]};
         `}
+        onClick={() => scrollToSection('help-section')}
       >
         Help
       </Button>

--- a/src/features/landing/components/helpers-section/helpers-section.tsx
+++ b/src/features/landing/components/helpers-section/helpers-section.tsx
@@ -12,7 +12,7 @@ import * as styles from './helpers-section.styles';
 export default function HelpersSection() {
   return (
     <>
-      <section css={styles.sectionWrapper}>
+      <section css={styles.sectionWrapper} id="features-section">
         <h2 css={styles.sectionTitle}>
           포트폴리오 제작하면서
           <br />

--- a/src/features/landing/landing-page.tsx
+++ b/src/features/landing/landing-page.tsx
@@ -14,9 +14,7 @@ export default function LandingPage() {
         <img src={totalEvaluationImage} css={styles.image} alt="total evalution image" />
       </div>
       <div css={styles.flexColumn(22)}>
-        <div id="features-section">
-          <HelpersSection />
-        </div>
+        <HelpersSection />
         <div id="help-section">
           <FAQ />
         </div>

--- a/src/features/landing/landing-page.tsx
+++ b/src/features/landing/landing-page.tsx
@@ -9,13 +9,17 @@ import * as styles from './landing-page.styles';
 export default function LandingPage() {
   return (
     <div css={styles.landingPage}>
-      <div css={styles.flexColumn(10)}>
+      <div css={styles.flexColumn(10)} id="start-section">
         <RoutingStartSection />
         <img src={totalEvaluationImage} css={styles.image} alt="total evalution image" />
       </div>
       <div css={styles.flexColumn(22)}>
-        <HelpersSection />
-        <FAQ />
+        <div id="features-section">
+          <HelpersSection />
+        </div>
+        <div id="help-section">
+          <FAQ />
+        </div>
         <RoutingBottomSection />
       </div>
     </div>


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #125 

## 🌱 주요 변경 사항
- LandingMiddleButton 컴포넌트 내 버튼에 onClick 이벤트를 추가했습니다.

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/b7d72209-5603-4fff-b0cc-9a586256ba6d


## 🗣 리뷰어에게 할 말 (선택)
헤더와 랜딩 페이지 요소가 서로 다른 컴포넌트에 있어 ref 대신 id를 사용하여 해당 섹션으로 스크롤 이동하도록 구현했습니다.
