### PR TITLE
[#144] - 헤더 스크롤 인터렉션 좌표 수정

### DIFF
--- a/src/common/utils/scroll-to-section.ts
+++ b/src/common/utils/scroll-to-section.ts
@@ -3,10 +3,13 @@ import gsap from 'gsap';
 
 import { HEADER_PLACEHOLER_HEIGHT_REM } from '../components/layout/header-navigation/header-navigation-layout.styles';
 
+const HEADER_PLACEHOLER_HEIGHT_PX = HEADER_PLACEHOLER_HEIGHT_REM * 10;
+
 export const scrollToSection = (id: string) => {
   const element = document.getElementById(id);
-
   if (!element) return;
+
+  const elementOffsetTop = element.offsetTop - HEADER_PLACEHOLER_HEIGHT_PX;
 
   if (id === 'help-section') {
     const projectsContainer = document.getElementById('projects-container');
@@ -14,14 +17,14 @@ export const scrollToSection = (id: string) => {
     gsap.to(window, {
       duration: 1,
       scrollTo: {
-        y: element.offsetTop + (projectsContainer?.clientWidth || 0) * 4,
+        y: elementOffsetTop + (projectsContainer?.clientWidth || 0) * 4,
       },
     });
   } else if (id.startsWith('feedback-') || id.endsWith('-section')) {
     gsap.to(window, {
       duration: 0.5,
       scrollTo: {
-        y: element.offsetTop - HEADER_PLACEHOLER_HEIGHT_REM * 10,
+        y: elementOffsetTop,
       },
     });
   } else {


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #144 

## 🌱 주요 변경 사항

헤더 스크롤 인터렉션으로 이동되는 좌표에서 가로 스크롤 부분 포함된 부분을 수정합니다.

1. 가로 스크롤을 위해 진행되는 부분에 특정 좌푯값을 계산하는 로직이 들어있습니다
2. 이를 헤더 스크롤 인터렉션과 결합하기 위해 1번의 로직에 헤더 높이만큼만 뺄셈을 진행했습니다.


## 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/420ea181-d556-4848-9058-996b532c7305)
![image](https://github.com/user-attachments/assets/1fb7fa5d-2dfc-41be-97f7-a2ab5a949d11)


