### PR TITLE
[#152] - FadeInDiv 확장성 개선

### DIFF
--- a/src/common/components/interaction/fade-in-wrapper.styles.ts
+++ b/src/common/components/interaction/fade-in-wrapper.styles.ts
@@ -1,0 +1,44 @@
+import { css } from '@emotion/react';
+
+interface FadeInWrapperProps extends TransitionOptionsType {
+  inView: boolean;
+}
+
+export interface TransitionOptionsType {
+  delay?: number;
+  transform?: string;
+  direction?: 'X' | 'Y' | 'Z';
+  distance?: `${number}px` | `${number}rem` | `${number}%`;
+  duration?: number;
+  easing?: string;
+  scale?: number; // 기본값 1
+  rotate?: `${number}deg`; // 기본값 0deg
+  blur?: `${number}px`; // 흐림 효과 (기본값 없음)
+  opacityStart?: number; // 초기에 얼마나 투명할지 (기본값 0)
+  customTransform?: string; // 완전 사용자 지정 transform
+}
+
+export const fadeInWrapper = ({
+  inView,
+  delay = 0,
+  transform,
+  customTransform,
+  direction = 'Y',
+  distance = '2rem',
+  duration = 0.6,
+  easing = 'ease-out',
+  scale = 1,
+  rotate = '0deg',
+  blur,
+  opacityStart = 0,
+}: FadeInWrapperProps) => css`
+  opacity: ${inView ? 1 : opacityStart};
+  transform: ${customTransform ||
+  transform ||
+  `translate${direction}(${inView ? '0' : distance}) scale(${scale}) rotate(${rotate})`};
+  filter: ${blur ? `blur(${inView ? '0px' : blur})` : 'none'};
+  transition:
+    opacity ${duration}s ${easing} ${delay}s,
+    transform ${duration}s ${easing} ${delay}s,
+    filter ${duration}s ${easing} ${delay}s;
+`;

--- a/src/common/components/interaction/fade-in-wrapper.tsx
+++ b/src/common/components/interaction/fade-in-wrapper.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ReactNode } from 'react';
+import { IntersectionOptions, useInView } from 'react-intersection-observer';
+
+import { SerializedStyles } from '@emotion/react';
+
+import * as styles from './fade-in-wrapper.styles';
+
+/** JSX에서 사용할 수 있는 HTML 엘리먼트의 타입 */
+type Elements = keyof JSX.IntrinsicElements;
+
+/**
+ * 1. HTML 엘리먼트 이름을 타입으로 받는 타입 (`div`, `span` 등)
+ * 2. props를 받아서 JSX 엘리먼트를 반환하는 함수형 컴포넌트를 타입으로 받는 타입
+ *
+ * @template P - props 타입
+ */
+type ElementType<P = any> =
+  | { [K in Elements]: P extends JSX.IntrinsicElements[K] ? K : never }[Elements]
+  | ((props: P) => JSX.Element);
+
+/**
+ * ElementType에 따른 동적 타입
+ * - `E`가 HTML 엘리먼트라면 해당 엘리먼트의 props 타입 반환
+ * - 그렇지 않으면 해당 컴포넌트의 props를 추론
+ *
+ * @template E - 엘리먼트 타입
+ */
+type ElementProps<E extends ElementType> = E extends Elements
+  ? JSX.IntrinsicElements[E]
+  : React.ComponentProps<E>;
+
+/**
+ * `as` 프로퍼티를 포함하여 `ElementProps`를 합친 타입
+ * `as`를 통해 다른 HTML 엘리먼트나 컴포넌트를 지정
+ *
+ * @template E - 엘리먼트 타입
+ */
+type FadeInWrapperProps<E extends ElementType> = {
+  as?: E; // `as` 프로퍼티는 HTML 엘리먼트나 컴포넌트를 동적으로 지정 가능
+  children: ReactNode;
+  additionalStyles?: SerializedStyles; // 추가적인 Emotion 스타일
+  transitionOptions?: styles.TransitionOptionsType; // 애니메이션 관련 CSS 옵션
+  intersectionOptions?: IntersectionOptions; // 뷰포트 진입 감지를 위한 옵션 (react-intersection-observer)
+} & Omit<ElementProps<E>, 'as'>;
+
+export default function FadeInWrapper<E extends ElementType>({
+  as,
+  children,
+  additionalStyles,
+  transitionOptions,
+  intersectionOptions,
+  ...props
+}: FadeInWrapperProps<E>) {
+  const $Element = as || 'div';
+  const { ref, inView } = useInView(intersectionOptions);
+
+  return (
+    <$Element
+      ref={ref}
+      css={[
+        styles.fadeInWrapper({
+          inView,
+          ...transitionOptions,
+        }),
+        additionalStyles,
+      ]}
+      {...props}
+    >
+      {children}
+    </$Element>
+  );
+}

--- a/src/features/landing/components/frequently-asked-questions/frequently-asked-questions.styles.ts
+++ b/src/features/landing/components/frequently-asked-questions/frequently-asked-questions.styles.ts
@@ -27,23 +27,17 @@ export const FAQWrapper = css`
 `;
 
 export const title = withTheme(
-  (theme, inView: boolean) => css`
+  (theme) => css`
     ${theme.fonts.HEADLINE.HEAD1}
     color: ${theme.colors.GRAY[100]} !important;
 
     ${mediaQueries.mobile} {
       ${theme.fonts.HEADLINE.HEAD6}
     }
-
-    opacity: ${inView ? 1 : 0};
-    transform: translateY(${inView ? '0' : '2rem'});
-    transition:
-      opacity 0.6s ease-out,
-      transform 0.6s ease-out;
   `,
 );
 
-export const accordionRoot = (inView: boolean) => css`
+export const accordionRoot = css`
   display: flex;
   flex-direction: column;
   gap: 2.4rem;
@@ -52,13 +46,6 @@ export const accordionRoot = (inView: boolean) => css`
   ${mediaQueries.mobile} {
     gap: 1.6rem;
   }
-
-  opacity: ${inView ? 1 : 0};
-  transform: translateY(${inView ? '0' : '2rem'});
-  transition:
-    opacity 0.6s ease-out,
-    transform 0.6s ease-out;
-  transition-delay: ${inView ? '0.5s' : '0s'};
 `;
 
 export const accordionItem = withTheme(

--- a/src/features/landing/components/frequently-asked-questions/frequently-asked-questions.tsx
+++ b/src/features/landing/components/frequently-asked-questions/frequently-asked-questions.tsx
@@ -1,51 +1,46 @@
-import { useInView } from 'react-intersection-observer';
-
 import { css } from '@emotion/react';
 import * as Accordion from '@radix-ui/react-accordion';
 
 import Icon from '@/common/components/icon/icon';
+import FadeInWrapper from '@/common/components/interaction/fade-in-wrapper';
 
 import { faqData } from '../../common/data';
 
 import * as styles from './frequently-asked-questions.styles';
 
 export default function FAQ() {
-  const { ref: FAQTitleRef, inView: FAQTitleInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-  });
-
-  const { ref: FAQRef, inView: FAQInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-    delay: FAQTitleInView ? 0.2 : 9999,
-  });
-
   return (
     <div css={styles.FAQWrapper}>
-      <p ref={FAQTitleRef} css={styles.title(FAQTitleInView)}>
+      <FadeInWrapper
+        as={'p'}
+        intersectionOptions={{ threshold: 0.3, triggerOnce: true }}
+        additionalStyles={styles.title()}
+      >
         자주 묻는 질문
-      </p>
-      <Accordion.Root type="multiple" ref={FAQRef} css={styles.accordionRoot(FAQInView)}>
-        {faqData.map(({ question, answer }) => (
-          <Accordion.Item key={question} value={question} css={styles.accordionItem}>
-            <Accordion.Header css={styles.accordionHeader}>
-              <Accordion.Trigger css={styles.accordionTrigger}>
-                {question}{' '}
-                <div css={styles.icon}>
-                  <Icon
-                    name="leftArrow"
-                    customStyle={css`
-                      cursor: pointer;
-                    `}
-                  />
-                </div>
-              </Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Content css={styles.accordionContent}>{answer}</Accordion.Content>
-          </Accordion.Item>
-        ))}
-      </Accordion.Root>
+      </FadeInWrapper>
+
+      <FadeInWrapper intersectionOptions={{ threshold: 0.3, triggerOnce: true }}>
+        <Accordion.Root type="multiple" css={styles.accordionRoot}>
+          {faqData.map(({ question, answer }) => (
+            <Accordion.Item key={question} value={question} css={styles.accordionItem}>
+              <Accordion.Header css={styles.accordionHeader}>
+                <Accordion.Trigger css={styles.accordionTrigger}>
+                  {question}{' '}
+                  <div css={styles.icon}>
+                    <Icon
+                      name="leftArrow"
+                      customStyle={css`
+                        cursor: pointer;
+                      `}
+                    />
+                  </div>
+                </Accordion.Trigger>
+              </Accordion.Header>
+              <Accordion.Content css={styles.accordionContent}>{answer}</Accordion.Content>
+            </Accordion.Item>
+          ))}
+        </Accordion.Root>
+      </FadeInWrapper>
     </div>
   );
 }

--- a/src/features/landing/components/helpers-section/detail-improvement.tsx
+++ b/src/features/landing/components/helpers-section/detail-improvement.tsx
@@ -1,9 +1,8 @@
 import { useState, useMemo, useCallback } from 'react';
-import { useInView } from 'react-intersection-observer';
 
 import { theme } from '@/assets/styles/theme';
 import Icon from '@/common/components/icon/icon';
-import FadeInDiv from '@/common/components/interaction/fade-in-div';
+import FadeInWrapper from '@/common/components/interaction/fade-in-wrapper';
 import useDeviceType from '@/common/hooks/use-device-type';
 
 import { detailImprovementData } from '../../common/data';
@@ -11,11 +10,6 @@ import { detailImprovementData } from '../../common/data';
 import * as styles from './detail-improvement.styles';
 
 export default function DetailImprovement() {
-  const { ref: detailImprovementRef, inView: detailImprovementInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-  });
-
   const { isMobile } = useDeviceType();
 
   const [currentImprovementKey, setCurrentImprovementKey] = useState(
@@ -32,11 +26,15 @@ export default function DetailImprovement() {
   }, []);
 
   return (
-    <FadeInDiv
-      ref={detailImprovementRef}
-      inView={detailImprovementInView}
-      delay={0.5}
+    <FadeInWrapper
       additionalStyles={styles.detailImprovementWrapper}
+      transitionOptions={{
+        delay: 0.5,
+      }}
+      intersectionOptions={{
+        threshold: 0.3,
+        triggerOnce: true,
+      }}
     >
       <ul css={styles.improvementItemWrapper}>
         {detailImprovementData.map(({ title }) => (
@@ -78,6 +76,6 @@ export default function DetailImprovement() {
           </>
         )}
       </div>
-    </FadeInDiv>
+    </FadeInWrapper>
   );
 }

--- a/src/features/landing/components/helpers-section/helpers-section.tsx
+++ b/src/features/landing/components/helpers-section/helpers-section.tsx
@@ -1,8 +1,6 @@
-import { useInView } from 'react-intersection-observer';
-
 import { theme } from '@/assets/styles/theme';
 import Icon from '@/common/components/icon/icon';
-import FadeInDiv from '@/common/components/interaction/fade-in-div';
+import FadeInWrapper from '@/common/components/interaction/fade-in-wrapper';
 import useDeviceType from '@/common/hooks/use-device-type';
 import { questionData, stepData } from '@/features/landing/common/data';
 import QuestionCard from '@/features/landing/components/helpers-section/question-card';
@@ -18,91 +16,27 @@ import * as styles from './helpers-section.styles';
 export default function HelpersSection() {
   const { isDesktop } = useDeviceType();
 
-  // 제목 ref 및 inView 상태
-  const { ref: cardTitleRef, inView: cardTitleInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-  });
-
-  const { ref: stepTitleRef, inView: stepTitleInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-  });
-
-  const { ref: totalEvaluationTitleRef, inView: totalEvaluationTitleInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-  });
-
-  const { ref: projectTitleRef, inView: projectTitleInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-  });
-
-  const { ref: detailImprovementTitleRef, inView: detailImprovementTitleInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-  });
-
-  // 질문 카드의 ref 및 inView 상태
-  const { ref: firstCardRef, inView: firstCardInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-    delay: cardTitleInView ? 0.2 : 9999,
-  });
-
-  const { ref: secondCardRef, inView: secondCardInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-    delay: firstCardInView ? 0.2 : 9999,
-  });
-
-  const { ref: thirdCardRef, inView: thirdCardInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-    delay: secondCardInView ? 0.2 : 9999,
-  });
-
-  const cardRefs = [firstCardRef, secondCardRef, thirdCardRef];
-  const cardInViews = [firstCardInView, secondCardInView, thirdCardInView];
-
-  // 단계 카드의 ref 및 inView 상태
-  const { ref: firstStepRef, inView: firstStepInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-    delay: stepTitleInView ? 0.2 : 9999,
-  });
-
-  const { ref: secondStepRef, inView: secondStepInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-    delay: firstStepInView ? 0.2 : 9999,
-  });
-
-  const stepRefs = [firstStepRef, secondStepRef];
-  const stepInViews = [firstStepInView, secondStepInView];
-
   return (
     <>
       <section css={styles.sectionWrapper} id="features-section">
-        <FadeInDiv
-          ref={cardTitleRef}
-          inView={cardTitleInView}
+        <FadeInWrapper
           additionalStyles={styles.titleWrapper}
+          intersectionOptions={{
+            threshold: 0.3,
+            triggerOnce: true,
+          }}
         >
           <h2 css={styles.sectionTitle}>
             포트폴리오 제작하면서
             <br />
             이런 경험 없으셨나요?
           </h2>
-        </FadeInDiv>
+        </FadeInWrapper>
         <div css={styles.contentWrapper(isDesktop ? 'row' : 'column')}>
           {questionData.map(({ question, description, author }, idx) => (
             <QuestionCard
               key={question}
               idx={idx}
-              ref={cardRefs[idx]}
-              inView={cardInViews[idx]}
               question={question}
               description={description}
               author={author}
@@ -112,24 +46,24 @@ export default function HelpersSection() {
       </section>
 
       <section css={styles.sectionWrapper}>
-        <FadeInDiv
-          ref={stepTitleRef}
-          inView={stepTitleInView}
-          additionalStyles={styles.titleWrapper}
+        <FadeInWrapper
+          as={'h2'}
+          additionalStyles={styles.sectionTitle()}
+          intersectionOptions={{
+            threshold: 0.3,
+            triggerOnce: true,
+          }}
         >
-          <h2 css={styles.sectionTitle}>
-            한 번의 PDF 업로드로
-            <br />
-            맞춤형 피드백을 받아보세요
-          </h2>
-        </FadeInDiv>
+          한 번의 PDF 업로드로
+          <br />
+          맞춤형 피드백을 받아보세요
+        </FadeInWrapper>
+
         <div css={styles.contentWrapper('column')}>
           {stepData.map(({ step, text, image, aspectRatio, width }, idx) => (
             <StepCard
               key={step}
               idx={idx}
-              ref={stepRefs[idx]}
-              inView={stepInViews[idx]}
               step={step}
               text={text}
               image={image}
@@ -141,10 +75,12 @@ export default function HelpersSection() {
       </section>
 
       <section css={styles.sectionWrapper}>
-        <FadeInDiv
-          ref={totalEvaluationTitleRef}
-          inView={totalEvaluationTitleInView}
+        <FadeInWrapper
           additionalStyles={styles.titleWrapper}
+          intersectionOptions={{
+            threshold: 0.3,
+            triggerOnce: true,
+          }}
         >
           <SectionBadge color={theme.colors.SORA[200]} text="종합 평가" />
           <h2 css={styles.sectionTitle}>
@@ -152,17 +88,19 @@ export default function HelpersSection() {
             <br />
             정량적으로 평가해드려요
           </h2>
-        </FadeInDiv>
+        </FadeInWrapper>
         <div css={styles.contentWrapper('column')}>
           <TotalEvaluationGrid />
         </div>
       </section>
 
       <section css={styles.sectionWrapper}>
-        <FadeInDiv
-          ref={projectTitleRef}
-          inView={projectTitleInView}
+        <FadeInWrapper
           additionalStyles={styles.titleWrapper}
+          intersectionOptions={{
+            threshold: 0.3,
+            triggerOnce: true,
+          }}
         >
           <SectionBadge color="#D7B1FF" text="프로젝트 평가" />
           <h2 css={styles.sectionTitle}>
@@ -170,15 +108,17 @@ export default function HelpersSection() {
             <br />
             단계별로 확인해요
           </h2>
-        </FadeInDiv>
+        </FadeInWrapper>
         <ProjectsWrapper />
       </section>
 
       <section css={styles.sectionWrapper}>
-        <FadeInDiv
-          ref={detailImprovementTitleRef}
-          inView={detailImprovementTitleInView}
+        <FadeInWrapper
           additionalStyles={styles.titleWrapper}
+          intersectionOptions={{
+            threshold: 0.3,
+            triggerOnce: true,
+          }}
         >
           <SectionBadge color="#C3C3D9" text="세부 개선점" />
           <h2 css={styles.sectionTitle}>
@@ -186,7 +126,7 @@ export default function HelpersSection() {
             <br />
             피드백 해드려요
           </h2>
-        </FadeInDiv>
+        </FadeInWrapper>
         <DetailImprovement />
       </section>
     </>

--- a/src/features/landing/components/helpers-section/question-card.tsx
+++ b/src/features/landing/components/helpers-section/question-card.tsx
@@ -1,6 +1,4 @@
-import { forwardRef } from 'react';
-
-import FadeInDiv from '@/common/components/interaction/fade-in-div';
+import FadeInWrapper from '@/common/components/interaction/fade-in-wrapper';
 
 import * as styles from './question-card.styles';
 
@@ -9,28 +7,25 @@ interface QuestionCardProps {
   idx: number;
   description: string;
   author: string;
-  inView: boolean;
 }
 
-const QuestionCard = forwardRef<HTMLDivElement, QuestionCardProps>(
-  ({ question, idx, description, author, inView }, ref) => {
-    return (
-      <FadeInDiv
-        ref={ref}
-        inView={inView}
-        delay={idx * 0.2}
-        additionalStyles={styles.questionCard()}
-      >
-        <div css={styles.textWrapper}>
-          <p css={styles.question}>{question}</p>
-          <p css={styles.description}>{description}</p>
-        </div>
-        <span css={styles.author}>{author}</span>
-      </FadeInDiv>
-    );
-  },
-);
-
-QuestionCard.displayName = 'QuestionCard';
-
-export default QuestionCard;
+export default function QuestionCard({ question, idx, description, author }: QuestionCardProps) {
+  return (
+    <FadeInWrapper
+      additionalStyles={styles.questionCard()}
+      intersectionOptions={{
+        threshold: 0.3,
+        triggerOnce: true,
+      }}
+      transitionOptions={{
+        delay: idx * 0.2,
+      }}
+    >
+      <div css={styles.textWrapper}>
+        <p css={styles.question}>{question}</p>
+        <p css={styles.description}>{description}</p>
+      </div>
+      <span css={styles.author}>{author}</span>
+    </FadeInWrapper>
+  );
+}

--- a/src/features/landing/components/helpers-section/step-card.tsx
+++ b/src/features/landing/components/helpers-section/step-card.tsx
@@ -1,11 +1,8 @@
-import { forwardRef } from 'react';
-
-import FadeInDiv from '@/common/components/interaction/fade-in-div';
+import FadeInWrapper from '@/common/components/interaction/fade-in-wrapper';
 
 import * as styles from './step-card.styles';
 
 interface StepCardProps {
-  inView: boolean;
   idx: number;
   step: string;
   text: string;
@@ -14,22 +11,50 @@ interface StepCardProps {
   width: number;
 }
 
-const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
-  ({ inView, idx, step, text, image, aspectRatio, width }, ref) => {
-    return (
-      <FadeInDiv ref={ref} inView={inView} delay={idx * 0.2} additionalStyles={styles.stepCard}>
-        <div css={styles.stepTextWrapper}>
-          <span css={styles.stepText}>{step}</span>
-          <p css={styles.stepExplainText}>{text}</p>
-        </div>
-        <div>
-          <img css={styles.image(aspectRatio, width)} src={image} alt={`${step}: ${text}`} />
-        </div>
-      </FadeInDiv>
-    );
-  },
-);
+export default function StepCard({ idx, step, text, image, aspectRatio, width }: StepCardProps) {
+  return (
+    <FadeInWrapper
+      additionalStyles={styles.stepCard}
+      transitionOptions={{
+        delay: idx * 0.2,
+      }}
+      intersectionOptions={{
+        threshold: 0.3,
+        triggerOnce: true,
+      }}
+    >
+      <div css={styles.stepTextWrapper}>
+        <span css={styles.stepText}>{step}</span>
+        <p css={styles.stepExplainText}>{text}</p>
+      </div>
+      <div>
+        <img css={styles.image(aspectRatio, width)} src={image} alt={`${step}: ${text}`} />
+      </div>
+    </FadeInWrapper>
+  );
+}
 
-StepCard.displayName = 'StepCard';
+// const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
+//   ({ idx, step, text, image, aspectRatio, width }) => {
+//     return (
+//       <FadeInWrapper
+//         additionalStyles={styles.stepCard}
+//         transitionOptions={{
+//           delay: idx * 0.2,
+//         }}
+//       >
+//         <div css={styles.stepTextWrapper}>
+//           <span css={styles.stepText}>{step}</span>
+//           <p css={styles.stepExplainText}>{text}</p>
+//         </div>
+//         <div>
+//           <img css={styles.image(aspectRatio, width)} src={image} alt={`${step}: ${text}`} />
+//         </div>
+//       </FadeInWrapper>
+//     );
+//   },
+// );
 
-export default StepCard;
+// StepCard.displayName = 'StepCard';
+
+// export default StepCard;

--- a/src/features/landing/components/routing-section/routing-bottom-section.tsx
+++ b/src/features/landing/components/routing-section/routing-bottom-section.tsx
@@ -1,9 +1,8 @@
-import { useInView } from 'react-intersection-observer';
 import { useNavigate } from 'react-router';
 
 import { Button } from '@/common/components/button/Button';
 import Icon from '@/common/components/icon/icon';
-import FadeInDiv from '@/common/components/interaction/fade-in-div';
+import FadeInWrapper from '@/common/components/interaction/fade-in-wrapper';
 import Spacing from '@/common/components/spacing/spacing';
 import useDeviceType from '@/common/hooks/use-device-type';
 
@@ -14,49 +13,47 @@ export default function RoutingBottomSection() {
 
   const { isMobile } = useDeviceType();
 
-  const { ref: iconRef, inView: iconInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-  });
-
-  const { ref: textRef, inView: textInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-    delay: iconInView ? 0.2 : 9999,
-  });
-
-  const { ref: buttonRef, inView: buttonInView } = useInView({
-    threshold: 0.3,
-    triggerOnce: true,
-    delay: textInView ? 0.2 : 9999,
-  });
-
   const handleNavigateToUpload = () => {
     navigate('/upload');
   };
 
   return (
     <section css={styles.flexColumn}>
-      <FadeInDiv ref={iconRef} inView={iconInView}>
+      <FadeInWrapper>
         <Icon name="symbol" width={isMobile ? 40 : 60} />
-      </FadeInDiv>
+      </FadeInWrapper>
+
       <Spacing size={isMobile ? 1.6 : 3.2} />
-      <p ref={textRef} css={styles.mainText('bottom', textInView)}>
+
+      <FadeInWrapper
+        as={'p'}
+        transitionOptions={{
+          delay: 0.4,
+        }}
+        additionalStyles={styles.mainText('bottom')}
+      >
         내 포트폴리오에 딱 맞는 피드백
         <br />
         지금 바로 시작해보세요.
-      </p>
+      </FadeInWrapper>
+
       <Spacing size={isMobile ? 3.1 : 4.8} />
-      <Button
-        ref={buttonRef}
-        size={isMobile ? 'xLarge' : 'xxLarge'}
-        usage="text"
-        variant="primary"
-        onClick={handleNavigateToUpload}
-        css={styles.button(buttonInView)}
+
+      <FadeInWrapper
+        as="div"
+        transitionOptions={{
+          delay: 0.6,
+        }}
       >
-        무료로 피드백 받기
-      </Button>
+        <Button
+          size={isMobile ? 'xLarge' : 'xxLarge'}
+          usage="text"
+          variant="primary"
+          onClick={handleNavigateToUpload}
+        >
+          무료로 피드백 받기
+        </Button>
+      </FadeInWrapper>
     </section>
   );
 }

--- a/src/features/landing/components/routing-section/routing-section.styles.ts
+++ b/src/features/landing/components/routing-section/routing-section.styles.ts
@@ -12,7 +12,7 @@ export const flexColumn = css`
 `;
 
 export const mainText = withTheme(
-  (theme, type: RoutingSectionPositionType, inView?: boolean) => css`
+  (theme, type: RoutingSectionPositionType) => css`
     background: linear-gradient(180deg, #fff 0%, #c6dfe9 100%);
     background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -41,13 +41,6 @@ export const mainText = withTheme(
       ${mediaQueries.mobile} {
         ${theme.fonts.HEADLINE.HEAD6}
       }
-
-      opacity: ${inView ? 1 : 0};
-      transform: translateY(${inView ? '0' : '2rem'});
-      transition:
-        opacity 0.6s ease-out,
-        transform 0.6s ease-out;
-      transition-delay: ${inView ? '0.4s' : '0s'};
     `}
   `,
 );


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #152 

## 🌱 주요 변경 사항
- FadeInDiv의 확장성을 개선하여 FadeInWrapper 컴포넌트 생성 및 적용

## 🗣 리뷰어에게 할 말 (선택)
인터랙션을 담당하는 공통 컴포넌트인 FadeInDiv의 확장성을 높이기 위해 FadeInWrapper 컴포넌트를 만들었습니다.
이 컴포넌트는 동적으로 태그를 지정할 수 있으며, `추가 스타일`, `react-intersection-observer 관련 옵션`, `인터랙션 관련 CSS 옵션`을 인자로 받도록 설계되었습니다. 컴포넌트를 보다 확장성 있게 관리하고자 위와 같이 props를 분리했는데, 구조적으로 더 나은 방향이 있다면 피드백 부탁드립니다!

또한, 애니메이션 관련해서 디자이너분들의 피드백을 받아 공통적으로 사용될 옵션이 있다면 추후 기본값으로 설정할 예정입니다.

🥕 태그에 따라 올바른 속성 타입을 추론할 수 있도록 하기 위해 [내 타입스크립트 코드가 이렇게 느릴 리 없어! | 2024 당근 테크 밋업](https://www.youtube.com/watch?v=g9FL8hKoNqE) 영상을 참고했습니다.
이전에 당근 테크 밋업에서 알게 되었던 내용인데, 이번 이슈를 해결하는 과정에서 떠올라 적용해 보았습니다. 도움이 많이 되어 공유드립니다! 