### PR TITLE
[#180] - 사이드바 상태에 따른 푸터 너비 조절

### DIFF
--- a/src/common/components/layout/footer/footer.tsx
+++ b/src/common/components/layout/footer/footer.tsx
@@ -1,16 +1,19 @@
+import { useContext } from 'react';
 import { useLocation } from 'react-router';
 
 import Icon from '@/common/components/icon/icon';
 import { PAGE_URL } from '@/common/constants/path';
 import useDeviceType from '@/common/hooks/use-device-type';
+import { SidebarContext } from '@/features/total-evaluation/components/context/sidebar/sidebar-context';
 
 import * as styles from './footer.styles';
 
 export default function Footer() {
   const { pathname } = useLocation();
   const { isMobile } = useDeviceType();
+  const { isSidebarOpen } = useContext(SidebarContext);
 
-  const isShortFooter = pathname.includes(PAGE_URL.TotalEvaluation);
+  const isShortFooter = pathname.includes(PAGE_URL.TotalEvaluation) && isSidebarOpen;
 
   return (
     <div css={styles.footer(isShortFooter)}>


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #180 

## 🌱 주요 변경 사항
- 사이드바 상태에 따라 푸터 너비 조절

## 📸 스크린샷 (선택)
<img width="934" alt="image" src="https://github.com/user-attachments/assets/fea23d9b-5510-4fe6-9bb2-cefe7d8f5270" />
<img width="932" alt="image" src="https://github.com/user-attachments/assets/bc2f98ac-3da9-45be-a6fe-146b99348fd8" />

## 🗣 리뷰어에게 할 말 (선택)
isSidebarOpen 값을 추가로 검사하여 사이드바 상태에 따라 푸터 너비가 조절되도록 수정했습니다.
isSidebarOpen의 기본값이 true로 설정되어 있어 다른 페이지에서도 true로 인식되어, total-evaluation 페이지에서만 적용되도록 조건을 수정했습니다.