### PR TITLE
[#175] - 히스토리 조회 모달 에러 UI 반영, 디자인 QA 반영

### DIFF
--- a/src/common/components/modal/base-modal.styles.ts
+++ b/src/common/components/modal/base-modal.styles.ts
@@ -10,8 +10,9 @@ interface ModalContentProps {
 
 export const modalOverlay = css`
   position: fixed;
-  inset: 0;
+  z-index: 5;
   background: rgb(0 0 0 / 80%);
+  inset: 0;
 `;
 
 export const modalContent = ({
@@ -31,6 +32,7 @@ export const modalContent = ({
   borderRadius: '1.6rem',
   boxShadow: '0 0.4rem 1.05rem 0 rgb(0 0 0 / 82%)',
   outline: 'none',
+  zIndex: 10,
   ...(width && { width }),
   ...(height && { height }),
   ...(padding && { padding }),

--- a/src/common/components/toast/toast-config.tsx
+++ b/src/common/components/toast/toast-config.tsx
@@ -4,40 +4,43 @@ export type ToastType =
   | 'loginFailure'
   | 'pdfSubmit'
   | 'getFeedbackFailure';
-import { iconTypes } from '@/common/types/icon-types';
+
+import { ReactNode } from 'react';
+
+import Icon from '../icon/icon';
 
 export const toastConfig: Record<
   ToastType,
-  { message: string; duration?: number; icon: iconTypes; iconPosition: 'left' | 'right' }
+  { message: string; duration?: number; icon: ReactNode; iconPosition: 'left' | 'right' }
 > = {
   aiCompleteLarge: {
     message: 'AI 분석이 끝났어요!',
     duration: Infinity,
-    icon: 'arrow-up',
+    icon: <Icon name="arrow-up" />,
     iconPosition: 'right',
   },
   aiCompleteSmall: {
     message: 'AI 분석이 끝났어요!',
     duration: 3000,
-    icon: 'arrow-right-with-tail',
+    icon: <Icon name="arrow-right-with-tail" />,
     iconPosition: 'right',
   },
   loginFailure: {
     message: '로그인에 실패했어요',
     duration: 3000,
-    icon: 'login-fail',
+    icon: <Icon name="login-fail" />,
     iconPosition: 'left',
   },
   pdfSubmit: {
     message: 'PDF 제출이 완료됐어요',
     duration: 3000,
-    icon: 'pdf-submit-success',
+    icon: <Icon name="pdf-submit-success" />,
     iconPosition: 'left',
   },
   getFeedbackFailure: {
     message: '피드백을 불러올 수 없어요',
     duration: Infinity,
-    icon: 'loading',
+    icon: <Icon name="loading" />,
     iconPosition: 'right',
   },
 };

--- a/src/common/components/toast/toast.tsx
+++ b/src/common/components/toast/toast.tsx
@@ -1,4 +1,3 @@
-import Icon from '@common/components/icon/icon';
 import * as ToastMessage from '@radix-ui/react-toast';
 
 import { toastConfig, ToastType } from './toast-config';
@@ -24,9 +23,9 @@ export default function Toast({ name, open, setOpen, onClick }: ToastProps) {
         css={styles.root(name)}
         onClick={onClick}
       >
-        {iconPosition === 'left' && <Icon name={icon} />}
+        {iconPosition === 'left' && icon}
         <ToastMessage.Title css={styles.title(name)}>{message}</ToastMessage.Title>
-        {iconPosition === 'right' && <Icon name={icon} />}
+        {iconPosition === 'right' && icon}
       </ToastMessage.Root>
 
       <ToastMessage.Viewport css={styles.viewport(name)} />

--- a/src/features/profile/components/recent-feedback-modal/recent-feedback-modal.styles.ts
+++ b/src/features/profile/components/recent-feedback-modal/recent-feedback-modal.styles.ts
@@ -23,7 +23,7 @@ export const closeIconWrapper = css`
   margin: 0.8rem 1rem;
 `;
 
-export const fallbackWrapper = css`
+export const fallbackLoadingWrapper = css`
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -32,3 +32,44 @@ export const fallbackWrapper = css`
   gap: 0.8rem;
   padding: 0 1rem;
 `;
+
+export const fallbackErrorWrapper = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  align-self: stretch;
+  flex-direction: column;
+  gap: 2rem;
+`;
+
+export const errorText = withTheme(
+  (theme) => css`
+    ${theme.fonts.SUBTITLE.SUB2_SB};
+    color: ${theme.colors.GRAY[300]};
+    text-align: center;
+  `,
+);
+
+export const buttonWrapper = withTheme(
+  (theme) => css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.7rem 1.2rem 0.7rem 1.6rem;
+    background: ${theme.colors.GRAY[200]};
+    border-radius: 0.8rem;
+    gap: 0.2rem;
+
+    &:hover {
+      background: ${theme.colors.GRAY[300]};
+    }
+  `,
+);
+
+export const buttonText = withTheme(
+  (theme) => css`
+    ${theme.fonts.SUBTITLE.SUB5_SB}
+    color: ${theme.colors.GRAY[950]};
+  `,
+);

--- a/src/features/profile/components/recent-feedback-modal/recent-feedback-modal.tsx
+++ b/src/features/profile/components/recent-feedback-modal/recent-feedback-modal.tsx
@@ -1,4 +1,5 @@
 import { colors } from '@/assets/styles/colors';
+import { BaseButton } from '@/common/components/button/base-button';
 import FallbackBoundary from '@/common/components/fallback-boundary/fallback-boundary';
 import Icon from '@/common/components/icon/icon';
 import Modal from '@/common/components/modal/base-modal';
@@ -38,14 +39,27 @@ export default function RecentFeedbackModal() {
 const fallbacks = {
   suspense: {
     fallbackUI: (
-      <div css={styles.fallbackWrapper}>
+      <div css={styles.fallbackLoadingWrapper}>
         <Skeleton width="5.4rem" />
         <Skeleton height="4.6rem" />
       </div>
     ),
   },
   error: {
-    // 에러 처리 디자인 나오면 적용할 예정입니다!
-    fallbackUI: <div css={styles.fallbackWrapper}>다시 시도</div>,
+    fallbackUI: (onReset: VoidFunction) => (
+      <div css={styles.fallbackErrorWrapper}>
+        <p css={styles.errorText}>
+          문제가 생겨
+          <br />
+          최근 피드백을 불러오는데 실패했어요
+        </p>
+        <BaseButton onClick={onReset}>
+          <div css={styles.buttonWrapper}>
+            <span css={styles.buttonText}>다시 불러오기</span>
+            <Icon name="loading" width={14} color="#2C2C36" />
+          </div>
+        </BaseButton>
+      </div>
+    ),
   },
 };

--- a/src/features/upload/components/feedback-loading/loading-page-evaluation.styles.ts
+++ b/src/features/upload/components/feedback-loading/loading-page-evaluation.styles.ts
@@ -85,7 +85,7 @@ export const shadowRight = (isShow?: boolean) => css`
     position: absolute;
     top: -1rem;
     right: -2rem;
-    z-index: 10;
+    z-index: 1;
     width: 5.5rem;
     height: 6.2rem;
     background: linear-gradient(90deg, rgb(24 23 29 / 0%) 0%, #18171d 100%);
@@ -100,7 +100,7 @@ export const shadowLeft = (isShow?: boolean) => css`
     position: absolute;
     top: -1rem;
     left: -2rem;
-    z-index: 10;
+    z-index: 1;
     width: 5.5rem;
     height: 6.2rem;
     background: linear-gradient(270deg, rgb(24 23 29 / 0%) 0%, #18171d 100%);
@@ -232,8 +232,11 @@ export const descriptionWrapper = css`
   flex-direction: column;
   align-items: flex-start;
   align-self: stretch;
-  padding-left: 3.2rem;
   gap: 0.6rem;
+
+  ${mediaQueries.tabletAndDesktop} {
+    padding-left: 3.2rem;
+  }
 
   ${mediaQueries.mobile} {
     gap: 0.8rem;

--- a/src/features/upload/components/feedback-loading/loading-top-section.tsx
+++ b/src/features/upload/components/feedback-loading/loading-top-section.tsx
@@ -55,7 +55,6 @@ export default function LoadingTopSection() {
       </FadeInWrapper>
       <Spacing size={isMobile ? 38 : 30} />
       <FadeInWrapper
-        as={'h3'}
         additionalStyles={styles.bottomWrapper}
         intersectionOptions={{
           threshold: 0.3,
@@ -65,10 +64,8 @@ export default function LoadingTopSection() {
           delay: 0.6,
         }}
       >
-        <div css={styles.bottomWrapper}>
-          <span css={styles.exampleDescription}>피드백 예시 보기</span>
-          <Icon name="feedback-loading-down-arrow" customStyle={styles.floating} />
-        </div>
+        <span css={styles.exampleDescription}>피드백 예시 보기</span>
+        <Icon name="feedback-loading-down-arrow" customStyle={styles.floating} />
       </FadeInWrapper>
     </>
   );


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #175 

## 🌱 주요 변경 사항

1. 히스토리 조회 모달에서 에러 UI 반영
2. 토스트 공통 컴포넌트에서 아이콘 이름이 아닌 아이콘 자체를 주입시키는 방법으로 변경
3. 디자인 QA에 따른 모달창 z-index 값 추가 및 세부 사항 수정

## 📸 스크린샷 (선택)

<img width="348" alt="스크린샷 2025-03-27 오후 4 36 05" src="https://github.com/user-attachments/assets/475e1df3-ab81-47b5-b339-87533056d1ee" />

