### PR TITLE
[#186] - 피드백 헤더 메타 데이터 추가

### DIFF
--- a/src/common/components/layout/header-buttons/total-evaluation/total-evaluation-user-info.tsx
+++ b/src/common/components/layout/header-buttons/total-evaluation/total-evaluation-user-info.tsx
@@ -1,6 +1,7 @@
 import FallbackBoundary from '@/common/components/fallback-boundary/fallback-boundary';
 import Skeleton from '@/common/components/skeleton/skeleton';
 import { useGetPortfolioFeedbackData } from '@/features/total-evaluation/hooks/use-get-portfolio-feedback-data';
+import { convertKrDate } from '@/features/total-evaluation/utils/convert-kr-date';
 
 import * as styles from './total-evaluation-user-info.styles';
 
@@ -19,10 +20,11 @@ export default TotalEvalutationUserInfo;
 
 const TotalEvalutationUserInfoContent = () => {
   const { createdAt, title } = useGetPortfolioFeedbackData();
+  const koreanDate = convertKrDate(createdAt);
 
   return (
     <div css={styles.container}>
-      <p css={styles.date}>{createdAt ?? '-'}</p>
+      <p css={styles.date}>{koreanDate ?? '-'}</p>
       <p css={styles.pdf}>{title}</p>
     </div>
   );

--- a/src/features/feedback/services/use-get-portfolio-feedback.ts
+++ b/src/features/feedback/services/use-get-portfolio-feedback.ts
@@ -68,9 +68,9 @@ interface AdditionalChatType {
 type Status = 'COMPLETE' | 'IN_PROGRESS' | 'PENDING' | 'ERROR';
 
 interface UseGetPortfolioFeedbackResponse {
-  createdAt: null;
-  updatedAt: null;
-  deletedAt: null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
   id: string;
   userId: string;
   fileId: string;

--- a/src/features/total-evaluation/utils/adapt-accordion-format.ts
+++ b/src/features/total-evaluation/utils/adapt-accordion-format.ts
@@ -1,9 +1,0 @@
-import { SidebarListType } from '../types/sidebar-Info-types';
-
-/* 도메인 데이터를 AccordionMenu 포맷으로 변환하는 어댑터 함수 **/
-export const adaptToAccordionFormat = (sidebarList: SidebarListType) => {
-  return sidebarList.map(({ projectTitle, feedbackPages }) => ({
-    accordionTrigger: projectTitle,
-    accordionContents: feedbackPages,
-  }));
-};

--- a/src/features/total-evaluation/utils/convert-kr-date.ts
+++ b/src/features/total-evaluation/utils/convert-kr-date.ts
@@ -1,0 +1,14 @@
+export const convertKrDate = (isoString: string) => {
+  const date = new Date(isoString);
+  const options = {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  } as const;
+
+  // 2025. 03. 27.
+  const koreanDate = date.toLocaleString('ko-KR', options).replace(/\.$/, '');
+
+  return koreanDate;
+};


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #186 

## 🌱 주요 변경 사항

피드백 페이지에 사용되는 헤더의 메타데이터를 추가합니다.
- PDF 생성 날짜
- PDF 제목


## 📸 스크린샷 (선택)


<img width="319" alt="image" src="https://github.com/user-attachments/assets/89cd1758-87c6-48cb-8884-6b9644ba5819" />

## 🗣 리뷰어에게 할 말 (선택)

현재 목데이터는 날짜값이 전부 `null`이므로 전부 `1970.01.01` 로 나오게 됩니다.
