### PR TITLE
[#188] - 포트폴리오 피드백 조회 에러 시 토스트 아이콘 수정

### DIFF
--- a/src/common/components/toast/toast-config.tsx
+++ b/src/common/components/toast/toast-config.tsx
@@ -7,6 +7,11 @@ export type ToastType =
 
 import { ReactNode } from 'react';
 
+import * as totalEvaluationStyles from '@features/total-evaluation/total-evaluation-page.styles';
+
+import { theme } from '@/assets/styles/theme';
+import { BaseButton } from '@/common/components/button/base-button';
+
 import Icon from '../icon/icon';
 
 export const toastConfig: Record<
@@ -40,7 +45,11 @@ export const toastConfig: Record<
   getFeedbackFailure: {
     message: '피드백을 불러올 수 없어요',
     duration: Infinity,
-    icon: <Icon name="loading" />,
+    icon: (
+      <BaseButton css={totalEvaluationStyles.getFeedbackFailureButton}>
+        <Icon name="loading" width={14} color={theme.colors.RED[400]} />
+      </BaseButton>
+    ),
     iconPosition: 'right',
   },
 };

--- a/src/features/total-evaluation/total-evaluation-page.styles.ts
+++ b/src/features/total-evaluation/total-evaluation-page.styles.ts
@@ -40,3 +40,9 @@ export const fallbackWrapper = css`
   margin: 0 auto;
   padding-top: 3.6rem;
 `;
+
+export const getFeedbackFailureButton = css`
+  padding: 0.6rem;
+  border-radius: 10rem;
+  background-color: rgb(233 97 80 / 15%);
+`;

--- a/src/features/total-evaluation/total-evaluation-page.tsx
+++ b/src/features/total-evaluation/total-evaluation-page.tsx
@@ -10,7 +10,6 @@ import OverallEvaluation from './components/overall-evaluation/overall-evaluatio
 
 import * as styles from './total-evaluation-page.styles';
 
-//TODO: Toast 아이콘 reactNode로 수정
 export default function TotalEvaluationPage() {
   const [toastOpen, setToastOpen] = useState(true);
 


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #188 

## 🌱 주요 변경 사항
- 포트폴리오 피드백 조회 에러 시 토스트 아이콘 수정

## 📸 스크린샷 (선택)
<img width="1497" alt="image" src="https://github.com/user-attachments/assets/71021eaa-1531-4ada-b9a2-2e68d3d54892" />
