### PR TITLE
[#195] - 피드백 상세 조회 응답 데이터 변경에 따른 대응

### DIFF
--- a/src/common/components/feedback-state-observer/feedback-state-observer.tsx
+++ b/src/common/components/feedback-state-observer/feedback-state-observer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
 
 import { getLocalStorage, removeLocalStorage } from '@/common/utils/storage';
@@ -12,13 +12,13 @@ const POLLING_INTERVAL = 5000;
  */
 export default function FeedbackStateObserver() {
   const navigate = useNavigate();
-  const { state, feedbackId, changeState } = useFeedbackStore();
+  const { feedbackId, changeState } = useFeedbackStore();
   const { data: feedback, refetch } = useGetPortfolioFeedbackForStatus({
     feedbackId,
   });
 
   const getFeedbackState = useCallback(() => {
-    const { overallStatus, projectStatus } = feedback?.result || {};
+    const { overallStatus, projectStatus } = feedback?.result.feedback || {};
 
     const isComplete = overallStatus === 'COMPLETE' && projectStatus === 'COMPLETE';
     const isError = overallStatus === 'ERROR' || projectStatus === 'ERROR';
@@ -37,12 +37,12 @@ export default function FeedbackStateObserver() {
       changeState('ERROR');
     } else if (isInProgress) {
       // 피드백 생성 중
-      changeState('IN_PROGRESS');
+      changeState('IN_PROGRESS', feedbackId);
 
       refetch();
     } else if (isPending) {
       // 피드백 생성 대기 중
-      changeState('PENDING');
+      changeState('PENDING', feedbackId);
 
       refetch();
     }
@@ -64,7 +64,7 @@ export default function FeedbackStateObserver() {
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [feedbackId, getFeedbackState, state]);
+  }, [feedbackId, getFeedbackState]);
 
   useEffect(() => {
     const feedbackIdinProgress = getLocalStorage('feedbackId', undefined);

--- a/src/common/components/feedback-state-observer/feedback-state-observer.tsx
+++ b/src/common/components/feedback-state-observer/feedback-state-observer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router';
 
 import { getLocalStorage, removeLocalStorage } from '@/common/utils/storage';

--- a/src/features/feedback/services/use-get-portfolio-feedback.ts
+++ b/src/features/feedback/services/use-get-portfolio-feedback.ts
@@ -68,18 +68,21 @@ interface AdditionalChatType {
 type Status = 'COMPLETE' | 'IN_PROGRESS' | 'PENDING' | 'ERROR';
 
 interface UseGetPortfolioFeedbackResponse {
-  createdAt: string;
-  updatedAt: string;
-  deletedAt: string;
-  id: string;
-  userId: string;
-  fileId: string;
-  title: string;
-  overallStatus: Status;
-  projectStatus: Status;
-  overallEvaluation: OverallEvaluationType;
-  additionalChat: AdditionalChatType[];
-  projectEvaluation: ProjectEvaluationType[];
+  feedback: {
+    createdAt: string;
+    updatedAt: string;
+    deletedAt: string;
+    id: string;
+    userId: string;
+    fileId: string;
+    title: string;
+    overallStatus: Status;
+    projectStatus: Status;
+    overallEvaluation: OverallEvaluationType;
+    additionalChat: AdditionalChatType[];
+    projectEvaluation: ProjectEvaluationType[];
+  };
+  imageList: string[];
 }
 
 interface UseGetPortfolioFeedbackParams {

--- a/src/features/total-evaluation/hooks/use-get-portfolio-feedback-data.ts
+++ b/src/features/total-evaluation/hooks/use-get-portfolio-feedback-data.ts
@@ -8,6 +8,6 @@ export const useGetPortfolioFeedbackData = () => {
   const { data } = useGetPortfolioFeedback({ feedbackId: feedbackId as string });
 
   return {
-    ...data.result,
+    ...data.result.feedback,
   };
 };

--- a/src/features/upload/components/portfolio-upload/portfolio-upload.tsx
+++ b/src/features/upload/components/portfolio-upload/portfolio-upload.tsx
@@ -28,10 +28,10 @@ export default function PortfolioUpload() {
               onSuccess: async (data) => {
                 const { id } = data.result;
 
-                await startFeedback(id);
+                const { feedbackId } = await startFeedback(id);
 
-                changeState('PENDING', id);
-                setLocalStorage('feedbackId', id);
+                changeState('PENDING', feedbackId);
+                setLocalStorage('feedbackId', feedbackId);
               },
               onError: () => {
                 changeState('ERROR');


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #195 

## 🌱 주요 변경 사항

- 피드백 요청 후 피드백 상세 조회할 때 fileId 대신 feedbackId를 사용하도록 수정했습니다.
  - 파일 업로드 후 피드백 상세 조회 시 에러가 발생했던 이유는.. id를 다른 걸 넣어서 그런 거였습니다... 허허...

- 피드백 상세 조회 응답 데이터 변경에 따라 `UseGetPortfolioFeedbackResponse` 응답 타입을 수정했습니다.
```js
interface UseGetPortfolioFeedbackResponse {
  feedback: {
    createdAt: string;
    updatedAt: string;
    deletedAt: string;
    id: string;
    userId: string;
    fileId: string;
    title: string;
    overallStatus: Status;
    projectStatus: Status;
    overallEvaluation: OverallEvaluationType;
    additionalChat: AdditionalChatType[];
    projectEvaluation: ProjectEvaluationType[];
  };
  imageList: string[];
}
```

## 🗣 리뷰어에게 할 말 (선택)

@Limgabi 피드백 상세 조회 부분 타입을 수정했습니다. 해당 부분 확인 후 변경되어야 할 부분이 있다면 확인 부탁드립니다! 🙇 
