### PR TITLE
[#194] - 히스토리 조회 모달 로직 수정

### DIFF
--- a/src/features/feedback/services/use-get-feedback-history.ts
+++ b/src/features/feedback/services/use-get-feedback-history.ts
@@ -12,16 +12,11 @@ interface UseGetFeedbackHistoryResponse {
   result: FeedbackItemType[];
 }
 
-export const useGetFeedbackHistory = (userId: string) => {
+export const useGetFeedbackHistory = () => {
   const endPoint = '/api/v1/feedback/recent/feedback';
 
   return useSuspenseQuery<UseGetFeedbackHistoryResponse>({
-    queryKey: [endPoint, userId],
-    queryFn: () =>
-      axiosInstance
-        .get(endPoint, {
-          params: { userId },
-        })
-        .then((res) => res.data),
+    queryKey: [endPoint],
+    queryFn: () => axiosInstance.get(endPoint).then((res) => res.data),
   });
 };

--- a/src/features/profile/components/recent-feedback-modal/recent-feedback-modal-content.styles.ts
+++ b/src/features/profile/components/recent-feedback-modal/recent-feedback-modal-content.styles.ts
@@ -26,6 +26,7 @@ export const modalDescription = css`
   gap: 2.4rem;
   align-self: stretch;
   padding-right: 0.4rem;
+  height: 100%;
   ${scrollbar}
 `;
 

--- a/src/features/profile/components/recent-feedback-modal/recent-feedback-modal-content.tsx
+++ b/src/features/profile/components/recent-feedback-modal/recent-feedback-modal-content.tsx
@@ -8,8 +8,14 @@ import { parseFeedbackData } from '@/features/profile/util/parse-feedback-data';
 
 import * as styles from './recent-feedback-modal-content.styles';
 
-export default function RecentFeedbackModalContent() {
-  const { data } = useGetFeedbackHistory('650e6f9b14a5f12a6b5c3f92');
+interface recentFeedbackModalContentProps {
+  closeModal: () => void;
+}
+
+export default function RecentFeedbackModalContent({
+  closeModal,
+}: recentFeedbackModalContentProps) {
+  const { data } = useGetFeedbackHistory();
   const parseData = parseFeedbackData(data.result);
   const [mainRef, setMainRef] = useState<HTMLElement | null>(null);
   const [bottomRef, setBottomRef] = useState<HTMLDivElement | null>(null);
@@ -18,6 +24,7 @@ export default function RecentFeedbackModalContent() {
 
   const handleNavigateToPortfolioDetail = (id: string) => {
     navigate(`/total-evaluation/${id}`);
+    closeModal();
   };
 
   return (

--- a/src/features/profile/components/recent-feedback-modal/recent-feedback-modal.tsx
+++ b/src/features/profile/components/recent-feedback-modal/recent-feedback-modal.tsx
@@ -29,7 +29,7 @@ export default function RecentFeedbackModal() {
           </Modal.Close>
         </header>
         <FallbackBoundary suspense={fallbacks.suspense} error={fallbacks.error}>
-          <RecentFeedbackModalContent />
+          <RecentFeedbackModalContent closeModal={closeModal} />
         </FallbackBoundary>
       </Modal.Root>
     </Modal>

--- a/src/features/upload/components/upload/upload.tsx
+++ b/src/features/upload/components/upload/upload.tsx
@@ -10,7 +10,7 @@ import RecentFeedback from '../recent-feedback/recent-feedback';
 import * as styles from './upload.styles';
 
 export default function FeedbackUpload() {
-  const { data: feedbackHistoryResponse } = useGetFeedbackHistory('650e6f9b14a5f12a6b5c3f92');
+  const { data: feedbackHistoryResponse } = useGetFeedbackHistory();
   const feedbackHistory = feedbackHistoryResponse?.result;
 
   return (


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #194 

## 🌱 주요 변경 사항

1. 히스토리 조회 모달에서 기존에 테스트를 위해 userId 를 하드코딩했던 로직 제거
2. 히스토리 조회 모달에서 히스토리 클릭했을때 모달이 사라지지 않는 버그 수정
3. 히스토리 조회 모달에서 콘텐츠가 안넘쳐도 스크롤이 약간씩 되고 스크롤바가 있는 로직 수정

## 📸 스크린샷 (선택)
<img width="541" alt="스크린샷 2025-04-01 오전 10 30 26" src="https://github.com/user-attachments/assets/ee570144-7d76-41a6-b0fc-31f49c0b4b03" />


