### PR TITLE
[#206] - 피드백 페이지 API 호출 위치 수정 등

### DIFF
--- a/src/features/feedback/services/use-get-feedback-history.ts
+++ b/src/features/feedback/services/use-get-feedback-history.ts
@@ -13,7 +13,7 @@ interface UseGetFeedbackHistoryResponse {
 }
 
 export const useGetFeedbackHistory = () => {
-  const endPoint = '/api/v1/feedback/recent/feedback';
+  const endPoint = '/api/v1/feedback/list';
 
   return useSuspenseQuery<UseGetFeedbackHistoryResponse>({
     queryKey: [endPoint],

--- a/src/features/upload/components/file-upload/file-upload.tsx
+++ b/src/features/upload/components/file-upload/file-upload.tsx
@@ -9,12 +9,12 @@ import { getValueOrHyphen } from '@/common/utils/get-value-or-hyphen';
 
 import * as styles from './file-upload.styles';
 
-const MAX_FILE_SIZE = 1024 * 1024 * 5;
+const MAX_FILE_SIZE = 1024 * 1024 * 50;
 
 const schema = z.object({
   file: z
     .instanceof(File, { message: '파일을 업로드해주세요' })
-    .refine((file) => file?.size <= MAX_FILE_SIZE, `5MB까지 업로드 가능합니다.`)
+    .refine((file) => file?.size <= MAX_FILE_SIZE, `50MB까지 업로드 가능합니다.`)
     .refine((file) => file?.type?.includes('pdf'), 'PDF 파일을 업로드해주세요.'),
 });
 

--- a/src/features/upload/components/recent-feedback/recent-feedback.tsx
+++ b/src/features/upload/components/recent-feedback/recent-feedback.tsx
@@ -1,22 +1,25 @@
 import Spacing from '@/common/components/spacing/spacing';
-import { FeedbackItemType } from '@/features/feedback/services/use-get-feedback-history';
+import { useGetFeedbackHistory } from '@/features/feedback/services/use-get-feedback-history';
 
 import RecentFeedbackList from './recent-feedback-list';
 import RecentFeedbackListItem from './recent-feedback-list-item';
 
 import * as styles from './recent-feedback.styles';
 
-interface RecentFeedbackProps {
-  history: FeedbackItemType[];
-}
+export default function RecentFeedback() {
+  const { data: feedbackHistoryResponse, isLoading } = useGetFeedbackHistory();
+  const feedbackHistory = feedbackHistoryResponse?.result;
 
-export default function RecentFeedback({ history }: RecentFeedbackProps) {
+  if (isLoading || feedbackHistory.length === 0) {
+    return null;
+  }
+
   return (
     <div css={styles.container}>
       <h3 css={styles.title}>최근 피드백</h3>
       <Spacing size={1.2} />
       <RecentFeedbackList>
-        {history.slice(0, 2).map((item) => (
+        {feedbackHistory.slice(0, 2).map((item) => (
           <RecentFeedbackListItem
             key={item.feedbackId}
             feedbackId={item.feedbackId}

--- a/src/features/upload/components/upload/upload.tsx
+++ b/src/features/upload/components/upload/upload.tsx
@@ -2,7 +2,7 @@
 
 // import { axiosInstance } from '@/common/services/service-config';
 
-import { useGetFeedbackHistory } from '@features/feedback/services/use-get-feedback-history';
+import FallbackBoundary from '@/common/components/fallback-boundary/fallback-boundary';
 
 import PortfolioUpload from '../portfolio-upload/portfolio-upload';
 import RecentFeedback from '../recent-feedback/recent-feedback';
@@ -10,9 +10,6 @@ import RecentFeedback from '../recent-feedback/recent-feedback';
 import * as styles from './upload.styles';
 
 export default function FeedbackUpload() {
-  const { data: feedbackHistoryResponse } = useGetFeedbackHistory();
-  const feedbackHistory = feedbackHistoryResponse?.result;
-
   return (
     <div css={styles.container}>
       <h1 css={styles.title}>PDF를 업로드해주세요</h1>
@@ -30,9 +27,9 @@ export default function FeedbackUpload() {
       >
         내 정보 확인(테스트용)
       </button> */}
-      {feedbackHistory && feedbackHistory?.length > 0 && (
-        <RecentFeedback history={feedbackHistory || []} />
-      )}
+      <FallbackBoundary>
+        <RecentFeedback />
+      </FallbackBoundary>
     </div>
   );
 }

--- a/src/features/upload/components/upload/upload.tsx
+++ b/src/features/upload/components/upload/upload.tsx
@@ -27,7 +27,7 @@ export default function FeedbackUpload() {
       >
         내 정보 확인(테스트용)
       </button> */}
-      <FallbackBoundary>
+      <FallbackBoundary suspense={{ fallbackUI: null }} error={{ fallbackUI: null }}>
         <RecentFeedback />
       </FallbackBoundary>
     </div>


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #206 

## 🌱 주요 변경 사항

- 최근 피드백 조회 API의 엔드포인트를 변경했습니다. `api/v1/feedback/recent/feedback` -> `api/v1/feedback/list`
  - 다만 API에 서버측 이슈가 있어서 현재 수정중입니다. [슬랙](https://depromeet16th.slack.com/archives/C0878EM877X/p1743598259565219?thread_ts=1743585886.409229&cid=C0878EM877X)
- 파일 업로드 용량 제한을 5MB -> 50MB 로 변경했습니다.
- RecentFeedback 컴포넌트를 FallbackBoundary로 감쌌습니다.
  - fallbackUI는 null로 설정했습니다. 최근 피드백이 없을 경우 UI가 없을 때에도 로딩 UI가 있을 경우 로딩 UI를 보여주다가 갑자기 사라지는 경험이 좋지 않을 것이라 판단해서 null 값으로 설정했습니다.
