### PR TITLE
[#215] - Layout 스타일 변경 및 페이지 높이 값 제거

### DIFF
--- a/src/common/components/layout/common-layout.styles.ts
+++ b/src/common/components/layout/common-layout.styles.ts
@@ -4,6 +4,10 @@ import { theme } from '@/assets/styles/theme';
 import { PageLabelKey } from '@/common/constants/path';
 
 export const container = (pageLabel: PageLabelKey) => css`
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+
   --background-bg: ${pageLabel === 'Landing' ? theme.colors.GRAY[1000] : theme.colors.GRAY.bg};
 
   /* 가상 요소를 사용해 전체 배경을 지정 */
@@ -14,4 +18,8 @@ export const container = (pageLabel: PageLabelKey) => css`
     content: '';
     background-color: var(--background-bg);
   }
+`;
+
+export const content = css`
+  flex: 1;
 `;

--- a/src/common/components/layout/common-layout.tsx
+++ b/src/common/components/layout/common-layout.tsx
@@ -16,7 +16,9 @@ function CommonLayout({ isHeader, pageLabel }: CommonLayoutProps) {
   return (
     <div css={styles.container(pageLabel)}>
       {isHeader && <HeaderNavigation pageLabel={pageLabel} />}
-      <Outlet />
+      <div css={styles.content}>
+        <Outlet />
+      </div>
       <Footer />
     </div>
   );

--- a/src/common/components/layout/footer/footer.styles.ts
+++ b/src/common/components/layout/footer/footer.styles.ts
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
 import { mediaQueries } from '@/assets/styles/device-width';
-import { FOOTER_HEIGHT } from '@/common/constants/layout';
 import { withTheme } from '@/common/utils/with-theme';
 
 export const footer = withTheme(
@@ -10,7 +9,6 @@ export const footer = withTheme(
     align-items: center;
     justify-content: space-between;
     width: ${isShortFooter ? 'calc(100% - 26.4rem)' : '100%'};
-    height: ${FOOTER_HEIGHT.DEFAULT};
     padding: 1.2rem 2rem;
     color: ${theme.colors.GRAY[300]} !important;
     margin-left: auto;
@@ -19,7 +17,6 @@ export const footer = withTheme(
     ${theme.fonts.SUBTITLE.SUB5_M}
 
     ${mediaQueries.mobile} {
-      height: ${FOOTER_HEIGHT.MOBILE};
       font-size: 1rem;
     }
   `,

--- a/src/common/constants/layout.ts
+++ b/src/common/constants/layout.ts
@@ -1,4 +1,0 @@
-export const FOOTER_HEIGHT = {
-  DEFAULT: '4.8rem',
-  MOBILE: '3.8rem',
-};

--- a/src/features/landing/components/helpers-section/total-evaluation-grid.styles.ts
+++ b/src/features/landing/components/helpers-section/total-evaluation-grid.styles.ts
@@ -18,7 +18,7 @@ export const firstLine = css`
   display: flex;
   gap: 2rem;
 
-  & > div:nth-child(1) {
+  & > div:nth-of-type(1) {
     flex-basis: 38.7rem;
     background: rgb(174 232 255 / 3%);
     border: 0 solid rgb(174 232 255 / 15%);
@@ -29,7 +29,7 @@ export const firstLine = css`
     }
   }
 
-  & > div:nth-child(2) {
+  & > div:nth-of-type(2) {
     flex: 1;
     background: rgb(215 176 255 / 3%);
     border: 0 solid rgb(213 178 255 / 15%);
@@ -38,11 +38,11 @@ export const firstLine = css`
   ${mediaQueries.mobileAndTablet} {
     flex-direction: column;
 
-    & > div:nth-child(1) {
+    & > div:nth-of-type(1) {
       flex: 1;
     }
 
-    & > div:nth-child(2) {
+    & > div:nth-of-type(2) {
       flex: 1;
     }
   }
@@ -56,13 +56,13 @@ export const secondLine = css`
   display: flex;
   gap: 2rem;
 
-  & > div:nth-child(1) {
+  & > div:nth-of-type(1) {
     background: rgb(58 255 10 / 4%);
     border: 0 solid #24242b;
     flex: 1;
   }
 
-  & > div:nth-child(2) {
+  & > div:nth-of-type(2) {
     background: rgb(255 117 104 / 3%);
     border: 0 solid #24242b;
     flex: 1;

--- a/src/features/login/login-page.styles.ts
+++ b/src/features/login/login-page.styles.ts
@@ -3,19 +3,15 @@ import { css } from '@emotion/react';
 import { mediaQueries } from '@/assets/styles/device-width';
 import { withTheme } from '@/common/utils/with-theme';
 
-import { FOOTER_HEIGHT } from './../../common/constants/layout';
-
 export const container = withTheme(
   (theme) => css`
     display: flex;
     align-items: center;
     justify-content: center;
     width: 100dvw;
-    height: calc(100dvh - ${FOOTER_HEIGHT.DEFAULT});
     background-color: ${theme.colors.GRAY.bg};
 
     ${mediaQueries.mobile} {
-      height: calc(100dvh - ${FOOTER_HEIGHT.MOBILE});
       margin: auto;
     }
   `,

--- a/src/features/total-evaluation/total-evaluation-page.styles.ts
+++ b/src/features/total-evaluation/total-evaluation-page.styles.ts
@@ -1,17 +1,9 @@
 import { css } from '@emotion/react';
 
-import { mediaQueries } from '@/assets/styles/device-width';
-import { FOOTER_HEIGHT } from '@/common/constants/layout';
-
 export const container = css`
   background-color: #18171d;
-  min-height: calc(100dvh - ${FOOTER_HEIGHT.DEFAULT});
   min-width: 100dvw;
   display: flex;
-
-  ${mediaQueries.mobile} {
-    height: calc(100dvh - ${FOOTER_HEIGHT.MOBILE});
-  }
 `;
 
 export const totalEvaluationSection = css`

--- a/src/features/upload/components/upload/upload.styles.ts
+++ b/src/features/upload/components/upload/upload.styles.ts
@@ -1,14 +1,12 @@
 import { css } from '@emotion/react';
 
 import { mediaQueries } from '@/assets/styles/device-width';
-import { FOOTER_HEIGHT } from '@/common/constants/layout';
 import { withTheme } from '@/common/utils/with-theme';
 
 export const container = css`
   display: flex;
   align-items: center;
   width: 100%;
-  height: calc(100dvh - ${FOOTER_HEIGHT.DEFAULT});
   margin: 0 auto;
   padding: 18.3rem 3.2rem 0;
   background: radial-gradient(
@@ -18,10 +16,8 @@ export const container = css`
   );
   flex-direction: column;
   max-width: 65rem;
-  overflow-y: auto;
 
   ${mediaQueries.mobile} {
-    height: calc(100dvh - ${FOOTER_HEIGHT.MOBILE});
     margin: auto;
   }
 `;


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #215 

## 🌱 주요 변경 사항

- Layout 컴포넌트의 스타일을 변경했습니다.
![image](https://github.com/user-attachments/assets/5c083fe8-bb4c-4fb5-abb5-5f5e18f27e5d)
전체 레이아웃을 flex 레이아웃으로 변경하고 Outlet을 감싼 div가 남은 영역을 차지하도록 수정했습니다.
기존 페이지 컴포넌트에 적용되어 있던 height 속성을 제거했습니다.

- total-evaludation-grid에서 사용한 nth-child 속성을 nth-of-type으로 변경했습니다.
  - nth-child의 경우 부모 요소 기준 몇 번째 자식인지 판별하고, nth-of-type의 경우 부모 요소 기준 해당 선택자가 적용된 태그 요소 중 몇 번째인지 판별합니다. SSR의 경우 style 태그가 추가될 때 nth-child는 의도한 대로 동작하지 않기 때문에 오류를 출력한다고 합니다. [참고한 글](https://velog.io/@leehyunho2001/Next.jsSSR%EC%97%90%EC%84%9C-nth-child-%EA%B2%BD%EA%B3%A0)

## 🗣 리뷰어에게 할 말

@Limgabi 푸터 관련 작업하시면서 수정한 코드를 제가 다시 수정하게 되었습니다! 확인 한 번 부탁드립니다 🙇 
