### PR TITLE
[#216] - scrollTrigger start 조건 수정

### DIFF
--- a/src/features/landing/components/helpers-section/projects-wrapper.tsx
+++ b/src/features/landing/components/helpers-section/projects-wrapper.tsx
@@ -31,7 +31,7 @@ export default function ProjectsWrapper() {
         {
           scrollTrigger: {
             trigger: container.current,
-            start: 'center center',
+            start: 'center-=56px center',
             pin: document.querySelector('#landing-container'),
             scrub: 1,
             toggleActions: 'play pause reverse pause',


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #216

## 🌱 주요 변경 사항

- scrollTrigger start 조건을 수정했습니다. trigger 요소의 center 기준 위로 56px 만큼 떨어진 지점이 시작점이 됩니다.

## 📸 스크린샷 (선택)
### AS-IS
<img width="1184" alt="스크린샷 2025-04-03 오후 10 46 32" src="https://github.com/user-attachments/assets/4d8e74ee-8a93-49bd-85ef-27e5f00d2ebe" />

### TO-BE
<img width="1182" alt="스크린샷 2025-04-03 오후 10 46 49" src="https://github.com/user-attachments/assets/155c15b6-e314-44c1-a06a-e3a4c463cd0c" />