### PR TITLE
[#219] - 랜딩 페이지 레이아웃 시프트 수정(gsap 설정 수정)

### DIFF
--- a/src/common/utils/scroll-to-section.ts
+++ b/src/common/utils/scroll-to-section.ts
@@ -12,12 +12,11 @@ export const scrollToSection = (id: string) => {
   const elementOffsetTop = element.offsetTop - HEADER_PLACEHOLER_HEIGHT_PX;
 
   if (id === 'help-section') {
-    const projectsContainer = document.getElementById('projects-container');
     // 기존 scrollIntoView 메서드로는 중간 가로 스크롤 영역 때문에 제대로 동작하지 않음.
     gsap.to(window, {
       duration: 1,
       scrollTo: {
-        y: elementOffsetTop + (projectsContainer?.clientWidth || 0) * 4,
+        y: elementOffsetTop,
       },
     });
   } else if (id.startsWith('feedback-') || id.endsWith('-section')) {

--- a/src/features/landing/components/helpers-section/projects-wrapper.styles.ts
+++ b/src/features/landing/components/helpers-section/projects-wrapper.styles.ts
@@ -8,5 +8,7 @@ export const projectContainer = css`
 `;
 
 export const projectScrollContainer = css`
-  width: 100%;
+  display: flex;
+  justify-content: center;
+  width: 100vw;
 `;

--- a/src/features/landing/components/helpers-section/projects-wrapper.styles.ts
+++ b/src/features/landing/components/helpers-section/projects-wrapper.styles.ts
@@ -1,20 +1,10 @@
 import { css } from '@emotion/react';
 
-import { mediaQueries } from '@/assets/styles/device-width';
-
 export const projectContainer = css`
   display: flex;
   overflow: hidden;
-  width: 100vw;
+  width: 100%;
   max-width: 103rem;
-
-  ${mediaQueries.tablet} {
-    margin: 0 2.4rem;
-  }
-
-  ${mediaQueries.mobile} {
-    margin: 0 2rem;
-  }
 `;
 
 export const projectScrollContainer = css`

--- a/src/features/landing/components/helpers-section/projects-wrapper.tsx
+++ b/src/features/landing/components/helpers-section/projects-wrapper.tsx
@@ -21,91 +21,90 @@ export default function ProjectsWrapper() {
   const swiperRef = useRef<SwiperType>();
   const container = useRef<HTMLDivElement>(null);
 
-  useGSAP(
-    () => {
-      const totalWidth = container.current?.offsetWidth || 0;
+  useGSAP(() => {
+    const totalWidth = container.current?.offsetWidth || 0;
 
-      gsap.fromTo(
-        container.current,
-        { x: 0 },
-        {
-          scrollTrigger: {
-            trigger: container.current,
-            start: 'center-=56px center',
-            pin: document.querySelector('#landing-container'),
-            scrub: 1,
-            toggleActions: 'play pause reverse pause',
-            end: () => '+=' + totalWidth * 4,
-            onUpdate: (update) => {
-              const progress = update.progress * 100;
-              const swiper = swiperRef.current;
+    gsap.fromTo(
+      container.current,
+      { x: 0 },
+      {
+        scrollTrigger: {
+          trigger: container.current,
+          pin: true,
+          start: 'center-=56px center',
+          scrub: 1,
+          toggleActions: 'play pause reverse pause',
+          end: () => '+=' + totalWidth * 4,
+          onUpdate: (update) => {
+            const progress = update.progress * 100;
+            const swiper = swiperRef.current;
 
-              // 첫 번째 슬라이더 영역일 때
-              if (progress < 25) {
-                // 첫 번째 슬라이더가 아닌 다른 슬라이더라면
-                // slideTo 중복 호출 방지를 위한 조건
-                if (swiper?.realIndex !== 0) {
-                  swiper?.slideTo(0);
-                }
-
-                return;
+            // 첫 번째 슬라이더 영역일 때
+            if (progress < 25) {
+              // 첫 번째 슬라이더가 아닌 다른 슬라이더라면
+              // slideTo 중복 호출 방지를 위한 조건
+              if (swiper?.realIndex !== 0) {
+                swiper?.slideTo(0);
               }
-              if (25 <= progress && progress < 50) {
-                if (swiper?.realIndex !== 1) {
-                  swiper?.slideTo(1);
-                }
 
-                return;
+              return;
+            }
+            if (25 <= progress && progress < 50) {
+              if (swiper?.realIndex !== 1) {
+                swiper?.slideTo(1);
               }
-              if (50 <= progress && progress < 75) {
-                if (swiper?.realIndex !== 2) {
-                  swiper?.slideTo(2);
-                }
 
-                return;
+              return;
+            }
+            if (50 <= progress && progress < 75) {
+              if (swiper?.realIndex !== 2) {
+                swiper?.slideTo(2);
               }
-              if (progress >= 75) {
-                if (swiper?.realIndex !== 3) {
-                  swiper?.slideTo(3);
-                }
 
-                return;
+              return;
+            }
+            if (progress >= 75) {
+              if (swiper?.realIndex !== 3) {
+                swiper?.slideTo(3);
               }
-            },
+
+              return;
+            }
           },
         },
-      );
-    },
-    {
-      scope: container,
-    },
-  );
+      },
+    );
+  });
 
   return (
-    <FadeInWrapper
-      additionalStyles={styles.projectContainer}
-      intersectionOptions={{
-        threshold: 0.3,
-        triggerOnce: true,
-      }}
-      transitionOptions={{
-        delay: 0.5,
+    <div
+      style={{
+        width: '100%',
+        height: 'fit-content',
       }}
     >
       <div ref={container} id="projects-container" css={styles.projectScrollContainer}>
-        <Swiper slidesPerView={1} onSwiper={(swiper) => (swiperRef.current = swiper)}>
-          {projectsData.map((project, index) => (
-            <SwiperSlide key={index}>
-              <Projects
-                imageUrl={project.image}
-                feedbackType={project.feedbackType}
-                feedbackDescription={project.feedbackDescription}
-                process={project.process}
-              />
-            </SwiperSlide>
-          ))}
-        </Swiper>
+        <FadeInWrapper
+          additionalStyles={styles.projectContainer}
+          intersectionOptions={{
+            threshold: 0.3,
+            triggerOnce: true,
+          }}
+        >
+          <Swiper slidesPerView={1} onSwiper={(swiper) => (swiperRef.current = swiper)}>
+            {projectsData.map((project, index) => (
+              <SwiperSlide key={index}>
+                <Projects
+                  imageUrl={project.image}
+                  feedbackType={project.feedbackType}
+                  feedbackDescription={project.feedbackDescription}
+                  process={project.process}
+                />
+              </SwiperSlide>
+            ))}
+          </Swiper>
+        </FadeInWrapper>
       </div>
-    </FadeInWrapper>
+    </div>
   );
 }

--- a/src/features/landing/components/helpers-section/projects-wrapper.tsx
+++ b/src/features/landing/components/helpers-section/projects-wrapper.tsx
@@ -79,7 +79,7 @@ export default function ProjectsWrapper() {
   return (
     <div
       style={{
-        width: '100%',
+        width: '100vw',
         height: 'fit-content',
       }}
     >


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #219

## 🌱 주요 변경 사항

- useGsap 내부 pin 관련 설정을 수정했습니다.
기존에는 #landing-container를 pin 설정해주고 있었는데 해당 코드 때문에 레이아웃 시프트가 발생하는 걸로 확인했습니다.
아직 저도 gsap 라이브러리에 대한 이해가 부족하다보니 설명이 애매한 점 양해해주세요 ㅠㅠ 추후 공부해서 정리하고 공유드리겠습니다!

- gsap 설정을 수정한 후 FadeInWrapper가 동작하지 않는 문제가 있어 FadeInWrapper의 위계를 수정했습니다.
위계 수정에 따라 스타일도 일부 수정했습니다.

- gsap 설정을 수정하면서 상단 헤더의 help 버튼 클릭 시 이동해야할 y 값을 변경했습니다.

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/649ee68f-7044-4863-9c05-00aa533e9364

로컬에서 빌드 후 테스트 해본 영상입니다. 초반에 깜빡이는 건 새로고침 하고 있는 건데 레이아웃 시프트가 발생하진 않았습니다.
