### PR TITLE
[#240] - 업로드 시 로딩 프로그레스바 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 
     <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" sizes="180x180" />
 
-    <title>Critix | your perfect AI</title>
+    <title>Critix | AI feedback for Designer</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/features/upload/components/file-upload/file-upload.styles.ts
+++ b/src/features/upload/components/file-upload/file-upload.styles.ts
@@ -81,3 +81,14 @@ export const folder = (isDisabled?: boolean) => css`
   opacity: ${isDisabled ? 0.3 : 1};
   cursor: ${isDisabled ? 'not-allowed' : 'pointer'};
 `;
+
+export const progress = css`
+  overflow: hidden;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: calc(100% - 9.6rem);
+  height: fit-content;
+  margin: 0 4.8rem 3.2rem;
+  border-radius: 999px;
+`;

--- a/src/features/upload/components/file-upload/file-upload.tsx
+++ b/src/features/upload/components/file-upload/file-upload.tsx
@@ -4,6 +4,7 @@ import { Controller, FieldValues, SubmitErrorHandler, useForm } from 'react-hook
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
+import BarChart from '@/common/components/bar-chart/bar-chart';
 import Icon from '@/common/components/icon/icon';
 import { getValueOrHyphen } from '@/common/utils/get-value-or-hyphen';
 
@@ -21,10 +22,17 @@ const schema = z.object({
 interface FileUploadProps {
   onSubmit: (data: FieldValues) => unknown;
   remainCount?: number;
+  isLoading?: boolean;
+  progress?: number;
 }
 
 // 파일 업로드용 컴포넌트
-export default function FileUpload({ onSubmit, remainCount }: FileUploadProps) {
+export default function FileUpload({
+  onSubmit,
+  remainCount,
+  isLoading,
+  progress,
+}: FileUploadProps) {
   const isDisabled = remainCount === 0;
 
   const { handleSubmit, control, setValue } = useForm({
@@ -71,10 +79,17 @@ export default function FileUpload({ onSubmit, remainCount }: FileUploadProps) {
             <div css={styles.description}>
               {isDisabled ? (
                 <p>이번 달에 사용 가능한 피드백을 모두 받았어요</p>
+              ) : isLoading ? (
+                'PDF 업로드 중...'
               ) : (
                 <p>이번 달 남은 피드백 횟수 {getValueOrHyphen(remainCount)}회</p>
               )}
             </div>
+            {progress && progress > 0 && (
+              <div css={styles.progress}>
+                <BarChart value={progress || 0} />
+              </div>
+            )}
           </div>
         )}
       />

--- a/src/features/upload/services/mutations.ts
+++ b/src/features/upload/services/mutations.ts
@@ -37,7 +37,6 @@ export const usePostPortfolioMutation = () => {
       onUploadProgress,
     }: PortfolioRequest & {
       onUploadProgress?: (progressEvent: AxiosProgressEvent) => void;
-      onDownloadProgress?: (progressEvent: AxiosProgressEvent) => void;
     }) => {
       const data = await postPortfolio({ file, onUploadProgress });
 

--- a/src/features/upload/services/mutations.ts
+++ b/src/features/upload/services/mutations.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { AxiosProgressEvent } from 'axios';
 
 import { useAuthStore } from '@/store/user-auth';
 
@@ -31,8 +32,15 @@ export const usePostPortfolioMutation = () => {
       if (!LAUNCHING_DAY_TMP_ACCESS_USER.includes(email!))
         throw new Error(LAUNCHING_DAY_TMP_ACCESS_ERROR_MESSAGE);
     },
-    mutationFn: async ({ file }: PortfolioRequest) => {
-      const data = await postPortfolio({ file });
+    mutationFn: async ({
+      file,
+      onUploadProgress,
+    }: PortfolioRequest & {
+      onUploadProgress?: (progressEvent: AxiosProgressEvent) => void;
+      onDownloadProgress?: (progressEvent: AxiosProgressEvent) => void;
+    }) => {
+      const data = await postPortfolio({ file, onUploadProgress });
+
       return data;
     },
   });

--- a/src/features/upload/services/post-portfolio.ts
+++ b/src/features/upload/services/post-portfolio.ts
@@ -8,10 +8,8 @@ import { PortfolioRequest, PortfolioResponse } from '../types/portfolio-types';
 export const postPortfolio = async ({
   file,
   onUploadProgress,
-  onDownloadProgress,
 }: PortfolioRequest & {
   onUploadProgress?: (progressEvent: AxiosProgressEvent) => void;
-  onDownloadProgress?: (progressEvent: AxiosProgressEvent) => void;
 }) => {
   const { data } = await axiosInstance.post<Response<PortfolioResponse>>(
     '/api/v1/files/portfolio',
@@ -23,7 +21,6 @@ export const postPortfolio = async ({
         'Content-Type': 'multipart/form-data',
       },
       onUploadProgress,
-      onDownloadProgress,
     },
   );
 

--- a/src/features/upload/services/post-portfolio.ts
+++ b/src/features/upload/services/post-portfolio.ts
@@ -1,9 +1,18 @@
+import { AxiosProgressEvent } from 'axios';
+
 import { axiosInstance } from '@/common/services/service-config';
 import type { Response } from '@/common/types/response';
 
 import { PortfolioRequest, PortfolioResponse } from '../types/portfolio-types';
 
-export const postPortfolio = async ({ file }: PortfolioRequest) => {
+export const postPortfolio = async ({
+  file,
+  onUploadProgress,
+  onDownloadProgress,
+}: PortfolioRequest & {
+  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void;
+  onDownloadProgress?: (progressEvent: AxiosProgressEvent) => void;
+}) => {
   const { data } = await axiosInstance.post<Response<PortfolioResponse>>(
     '/api/v1/files/portfolio',
     {
@@ -13,6 +22,8 @@ export const postPortfolio = async ({ file }: PortfolioRequest) => {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
+      onUploadProgress,
+      onDownloadProgress,
     },
   );
 


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #240

## 🌱 주요 변경 사항

업로드 시 로딩 프로그레스바를 추가했습니다.
axios의 onUploadProgress를 사용했는데, 업로드 자체만 값을 가져올 수 있고 실제로 클라이언트에서 응답을 받았는지는 알 수 없어서 프로그레스바와 살제 호출 완료 시점에는 차이가 존재합니다.

타이틀명을 변경했습니다.

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/91715c1f-c161-4e42-85cc-b0b7385aa3df
