### PR TITLE
[#269] -  비로그인 상태일때 toast 제거

### DIFF
--- a/src/common/components/layout/header-buttons/profile-dropdown.tsx
+++ b/src/common/components/layout/header-buttons/profile-dropdown.tsx
@@ -6,6 +6,7 @@ import { useClearAuth } from '@/common/hooks/use-auth-cycle';
 import { getValueOrHyphen } from '@/common/utils/get-value-or-hyphen';
 import { useGetFeedbackHistory } from '@/features/feedback/services/use-get-feedback-history';
 import { useGetRemainingCountQuery } from '@/features/upload/services/queries';
+import { useFeedbackStore } from '@/store/feedback';
 import { useModalStore } from '@/store/modal';
 
 import AuthProfile from './auth-profile';
@@ -26,6 +27,9 @@ function ProfileDropdown() {
   const { openModal } = useModalStore();
 
   const { logout } = useClearAuth();
+
+  const { changeState } = useFeedbackStore();
+
   return (
     <DropdownMenu.Root
       defaultOpen={false}
@@ -72,6 +76,7 @@ function ProfileDropdown() {
               label="로그아웃"
               handleClick={async () => {
                 setIsDropdownOpen(false);
+                changeState('IDLE');
                 await logout();
               }}
             />

--- a/src/common/hooks/use-toast.ts
+++ b/src/common/hooks/use-toast.ts
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router';
 
 import { ToastType } from '@/common/components/toast/toast-config';
 import { useFeedbackStore, ProcessState } from '@/store/feedback';
+import { useAuthStore } from '@/store/user-auth';
 
 const mapProcessStateToToastType = (state: ProcessState): ToastType | null => {
   switch (state) {
@@ -18,10 +19,17 @@ const mapProcessStateToToastType = (state: ProcessState): ToastType | null => {
 
 export const useToast = () => {
   const navigate = useNavigate();
-
   const { state, changeState } = useFeedbackStore();
+  const { isLogin } = useAuthStore();
 
+  const toastType = mapProcessStateToToastType(state);
   const [toastOpen, setToastOpen] = useState(true);
+
+  useEffect(() => {
+    if (!isLogin) {
+      changeState('IDLE');
+    }
+  }, [isLogin, changeState]);
 
   const navigateTotalEvaluationPage = () => {
     if (state === 'ERROR') {
@@ -29,8 +37,6 @@ export const useToast = () => {
       navigate('/upload');
     }
   };
-
-  const toastType = mapProcessStateToToastType(state);
 
   return {
     toastType,

--- a/src/common/hooks/use-toast.ts
+++ b/src/common/hooks/use-toast.ts
@@ -1,9 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { ToastType } from '@/common/components/toast/toast-config';
 import { useFeedbackStore, ProcessState } from '@/store/feedback';
-import { useAuthStore } from '@/store/user-auth';
 
 const mapProcessStateToToastType = (state: ProcessState): ToastType | null => {
   switch (state) {
@@ -19,17 +18,10 @@ const mapProcessStateToToastType = (state: ProcessState): ToastType | null => {
 
 export const useToast = () => {
   const navigate = useNavigate();
+
   const { state, changeState } = useFeedbackStore();
-  const { isLogin } = useAuthStore();
 
-  const toastType = mapProcessStateToToastType(state);
   const [toastOpen, setToastOpen] = useState(true);
-
-  useEffect(() => {
-    if (!isLogin) {
-      changeState('IDLE');
-    }
-  }, [isLogin, changeState]);
 
   const navigateTotalEvaluationPage = () => {
     if (state === 'ERROR') {
@@ -37,6 +29,8 @@ export const useToast = () => {
       navigate('/upload');
     }
   };
+
+  const toastType = mapProcessStateToToastType(state);
 
   return {
     toastType,


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #269

## 🌱 주요 변경 사항

비로그인 상태일때 toast 제거

🗣 리뷰어에게 할 말 (선택)
- 아직 로그아웃후에 로그인하면 다시 풀링 api 보내는 로직이 없어 로그아웃 한 다음 로그인을 하면 다시 toast가 나오지 않습니다. 추후에 고쳐야 할 것 같습니다.