### PR TITLE
[#249] - 랜딩 페이지 가로 스크롤 영역 버그 수정

### DIFF
--- a/src/features/landing/components/helpers-section/detail-improvement.tsx
+++ b/src/features/landing/components/helpers-section/detail-improvement.tsx
@@ -1,5 +1,7 @@
 import { useState, useMemo, useCallback } from 'react';
 
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
 import { theme } from '@/assets/styles/theme';
 import Icon from '@/common/components/icon/icon';
 import FadeInWrapper from '@/common/components/interaction/fade-in-wrapper';
@@ -77,6 +79,7 @@ export default function DetailImprovement() {
               src={`${TMP_AWS_IMAGE_BASE_URL}/${extractImageFilename(currentImprovementData.image)}`}
               width={624}
               alt={`${currentImprovementData.title} image`}
+              onLoad={() => ScrollTrigger.refresh()}
             />
 
             <div css={styles.improvementTextWrapper}>

--- a/src/features/landing/components/helpers-section/helpers-section.styles.ts
+++ b/src/features/landing/components/helpers-section/helpers-section.styles.ts
@@ -3,6 +3,10 @@ import { css } from '@emotion/react';
 import { mediaQueries } from '@/assets/styles/device-width';
 import { withTheme } from '@/common/utils/with-theme';
 
+export const sectionContainer = css`
+  width: 100%;
+`;
+
 export const sectionWrapper = css`
   display: flex;
   flex-direction: column;

--- a/src/features/landing/components/helpers-section/helpers-section.tsx
+++ b/src/features/landing/components/helpers-section/helpers-section.tsx
@@ -93,23 +93,25 @@ export default function HelpersSection() {
         </div>
       </section>
 
-      <section css={styles.sectionWrapper}>
-        <FadeInWrapper
-          additionalStyles={styles.titleWrapper}
-          intersectionOptions={{
-            threshold: 0.3,
-            triggerOnce: true,
-          }}
-        >
-          <SectionBadge color="#D7B1FF" text="프로젝트 평가" />
-          <h2 css={styles.sectionTitle}>
-            프로젝트 과정에서 놓친 부분은 없는지
-            <br />
-            단계별로 확인해요
-          </h2>
-        </FadeInWrapper>
-        <ProjectsWrapper />
-      </section>
+      <div id="project-section-wrapper" css={styles.sectionContainer}>
+        <section id="project-section" css={styles.sectionWrapper}>
+          <FadeInWrapper
+            additionalStyles={styles.titleWrapper}
+            intersectionOptions={{
+              threshold: 0.3,
+              triggerOnce: true,
+            }}
+          >
+            <SectionBadge color="#D7B1FF" text="프로젝트 평가" />
+            <h2 css={styles.sectionTitle}>
+              프로젝트 과정에서 놓친 부분은 없는지
+              <br />
+              단계별로 확인해요
+            </h2>
+          </FadeInWrapper>
+          <ProjectsWrapper />
+        </section>
+      </div>
 
       <section css={styles.sectionWrapper}>
         <FadeInWrapper

--- a/src/features/landing/components/helpers-section/projects-wrapper.tsx
+++ b/src/features/landing/components/helpers-section/projects-wrapper.tsx
@@ -24,56 +24,52 @@ export default function ProjectsWrapper() {
   useGSAP(() => {
     const totalWidth = container.current?.offsetWidth || 0;
 
-    gsap.fromTo(
-      container.current,
-      { x: 0 },
-      {
-        scrollTrigger: {
-          trigger: container.current,
-          pin: true,
-          start: 'center-=56px center',
-          scrub: 1,
-          toggleActions: 'play pause reverse pause',
-          end: () => '+=' + totalWidth * 4,
-          onUpdate: (update) => {
-            const progress = update.progress * 100;
-            const swiper = swiperRef.current;
+    gsap.to('#project-section-wrapper', {
+      scrollTrigger: {
+        trigger: '#project-section',
+        pin: true,
+        start: 'center center',
+        scrub: 1,
+        toggleActions: 'play pause reverse pause',
+        end: () => '+=' + totalWidth * 4,
+        onUpdate: (update) => {
+          const progress = update.progress * 100;
+          const swiper = swiperRef.current;
 
-            // 첫 번째 슬라이더 영역일 때
-            if (progress < 25) {
-              // 첫 번째 슬라이더가 아닌 다른 슬라이더라면
-              // slideTo 중복 호출 방지를 위한 조건
-              if (swiper?.realIndex !== 0) {
-                swiper?.slideTo(0);
-              }
-
-              return;
+          // 첫 번째 슬라이더 영역일 때
+          if (progress < 25) {
+            // 첫 번째 슬라이더가 아닌 다른 슬라이더라면
+            // slideTo 중복 호출 방지를 위한 조건
+            if (swiper?.realIndex !== 0) {
+              swiper?.slideTo(0);
             }
-            if (25 <= progress && progress < 50) {
-              if (swiper?.realIndex !== 1) {
-                swiper?.slideTo(1);
-              }
 
-              return;
+            return;
+          }
+          if (25 <= progress && progress < 50) {
+            if (swiper?.realIndex !== 1) {
+              swiper?.slideTo(1);
             }
-            if (50 <= progress && progress < 75) {
-              if (swiper?.realIndex !== 2) {
-                swiper?.slideTo(2);
-              }
 
-              return;
+            return;
+          }
+          if (50 <= progress && progress < 75) {
+            if (swiper?.realIndex !== 2) {
+              swiper?.slideTo(2);
             }
-            if (progress >= 75) {
-              if (swiper?.realIndex !== 3) {
-                swiper?.slideTo(3);
-              }
 
-              return;
+            return;
+          }
+          if (progress >= 75) {
+            if (swiper?.realIndex !== 3) {
+              swiper?.slideTo(3);
             }
-          },
+
+            return;
+          }
         },
       },
-    );
+    });
   });
 
   return (

--- a/src/features/landing/components/helpers-section/projects.tsx
+++ b/src/features/landing/components/helpers-section/projects.tsx
@@ -1,3 +1,5 @@
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
 import Icon from '@/common/components/icon/icon';
 import useDeviceType from '@/common/hooks/use-device-type';
 
@@ -31,6 +33,7 @@ export default function Projects({
           <img
             src={`${TMP_AWS_IMAGE_BASE_URL}/${extractImageFilename(imageUrl)}`}
             alt="프로젝트 피드백"
+            onLoad={() => ScrollTrigger.refresh()}
           />
         </div>
         <div css={styles.description}>{feedbackDescription}</div>

--- a/src/features/landing/components/helpers-section/step-card.tsx
+++ b/src/features/landing/components/helpers-section/step-card.tsx
@@ -1,3 +1,5 @@
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
 import FadeInWrapper from '@/common/components/interaction/fade-in-wrapper';
 
 import { TMP_AWS_IMAGE_BASE_URL } from '../../landing-page';
@@ -38,6 +40,7 @@ export default function StepCard({ idx, step, text, image, aspectRatio, width }:
           css={styles.image(aspectRatio, width)}
           src={`${TMP_AWS_IMAGE_BASE_URL}/${extractImageFilename(image)}`}
           alt={`${step}: ${text}`}
+          onLoad={() => ScrollTrigger.refresh()}
         />
       </div>
     </FadeInWrapper>

--- a/src/features/landing/components/helpers-section/total-evaluation-grid.tsx
+++ b/src/features/landing/components/helpers-section/total-evaluation-grid.tsx
@@ -2,6 +2,7 @@
 // import gradeSmall from '@assets/images/grade-small.png';
 // import grade from '@assets/images/grade.png';
 import { css } from '@emotion/react';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
 
 import { theme } from '@/assets/styles/theme';
 import Icon from '@/common/components/icon/icon';
@@ -55,6 +56,7 @@ export default function TotalEvaluationGrid() {
                     : `${TMP_AWS_IMAGE_BASE_URL}/grade.png`
                 }
                 alt="등급"
+                onLoad={() => ScrollTrigger.refresh()}
               />
             </div>
           </div>
@@ -85,6 +87,7 @@ export default function TotalEvaluationGrid() {
             <img
               src={`${TMP_AWS_IMAGE_BASE_URL}/detail-evaluation-chart.png`}
               alt="세부 평가 차트"
+              onLoad={() => ScrollTrigger.refresh()}
             />
           </div>
         </FadeInWrapper>

--- a/src/features/landing/landing-page.tsx
+++ b/src/features/landing/landing-page.tsx
@@ -3,6 +3,8 @@ import { useInView } from 'react-intersection-observer';
 
 // import { css } from '@emotion/react';
 
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
 import { useAuthCycle } from '@/common/hooks/use-auth-cycle';
 import useDeviceType from '@/common/hooks/use-device-type';
 // import { axiosInstance } from '@/common/services/service-config';
@@ -51,6 +53,7 @@ export default function LandingPage() {
           src={`${TMP_AWS_IMAGE_BASE_URL}/total-evaluation.png`}
           css={styles.image(inView)}
           alt="total evalution image"
+          onLoad={() => ScrollTrigger.refresh()}
         />
       </div>
       <div css={styles.flexColumn(isMobile ? 16 : 22)}>


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #249

## 🌱 주요 변경 사항

- 가로 스크롤을 위한 helper section 마크업 수정 및  project-wrapper 내부 gsap 코드를 수정했습니다.
  - 마크업을 변경하면서 기존에는 섹션 타이틀이 화면에 고정되어 있지 않았는데, 가로 스크롤 영역과 함께 고정되도록 수정했습니다.
- 랜딩 페이지의 img 태그에 onLoad 핸들러로 ScrollTrigger.refresh() 함수를 호출하도록 했습니다.
  - 런칭데이 때 가로 스크롤 영역이 이상한 위치에서 고정되거나 다른 요소와 겹치는 문제가 있었는데, 이미지가 로드되면서 레이아웃이 변경되어, 변경된 레이아웃을 계산하지 못해서 발생하는 이슈라고 합니다. 마땅한 방법이 생각나지 않아서 랜딩 페이지 내부 이미지가 로드될 때마다 가로 스크롤을 위한 레이아웃 재계산을 수행합니다. [참고 문서](https://gsap.com/community/forums/topic/41098-wrong-start-and-end-position-on-mobile-devices/)
  다만 확실하게 해결되었다고는 확신할 수 없어서 비슷한 버그가 발생하는지 계속 확인해야 할 것 같습니다 ㅠㅠ
