### PR TITLE
[#276] - 진행중인 피드백 id 저장 방식 변경

### DIFF
--- a/src/common/components/global-route-config/global-route-config.tsx
+++ b/src/common/components/global-route-config/global-route-config.tsx
@@ -9,7 +9,6 @@ import FeedbackStateObserver from '../feedback-state-observer/feedback-state-obs
 
 /** 전역적으로 사용되는 로직들을 라우팅 최상단에 배치하는 Config 컴포넌트 */
 export default function GlobalRouteConfig() {
-
   const { toastType, toastOpen, setToastOpen, navigateTotalEvaluationPage } = useToast();
 
   const { isLogin, userInfo } = useAuthStore();

--- a/src/common/hooks/use-toast.ts
+++ b/src/common/hooks/use-toast.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { ToastType } from '@/common/components/toast/toast-config';
@@ -31,6 +31,14 @@ export const useToast = () => {
   };
 
   const toastType = mapProcessStateToToastType(state);
+
+  useEffect(() => {
+    if (toastType) {
+      setToastOpen(true);
+    } else {
+      setToastOpen(false);
+    }
+  }, [toastType]);
 
   return {
     toastType,

--- a/src/features/landing/components/routing-section/routing-start-section.tsx
+++ b/src/features/landing/components/routing-section/routing-start-section.tsx
@@ -17,7 +17,7 @@ export default function RoutingStartSection() {
   return (
     <section css={styles.flexColumn}>
       <p css={styles.mainText('start')}>
-        Just upload <br />
+        Just Upload <br />
         Your Portfolio
       </p>
       <Spacing size={isMobile ? 1.6 : 3.2} />


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #276

## 🌱 주요 변경 사항

- 진행중인 피드백을 이메일 별로 관리하도록 수정했습니다.
  - 로그아웃 하거나 다른 계정으로 로그인 했을 때 API 폴링을 하지 않기 위함입니다.
  - 커밋을 쪼개지 못했는데, 에러가 발생했을 때 프로그레스 바를 보여주지 않도록 수정했습니다.
- toastType이 truthy일 경우 toastOpen 상태를 true로 설정하도록 수정했습니다.
  - 토스트가 떴다가 사라지면 다음 토스트가 뜨지 않는 문제를 해결하기 위함입니다. toastOpen 상태에 따라 토스트를 보여주고 있는데, 초기 상태가 true이고 toast가 닫히면서 false로 변경되는데, 다음 토스트가 떠야할 시점에 toastOpen 상태를 true로 변경하지 않고 있기 때문에 토스트가 보이지 않는 버그가 있었습니다. 

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/37ce31da-d11a-4547-b0d7-657b606dcf86

1. 업로드 에러 -> 업로드 에러 -> 피드백 시작 시 각 스텝마다 토스트가 잘 뜹니다.
2. 피드백 시작 후 로그아웃 시 피드백 진행중 토스트가 뜨지 않습니다.
