### PR TITLE
[#307] - FadeInWrapper 엘리먼트 제네릭 기본값 any 제거하며 유니온 타입으로 변경

### DIFF
--- a/src/common/components/interaction/fade-in-wrapper.tsx
+++ b/src/common/components/interaction/fade-in-wrapper.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ReactNode } from 'react';
 import { IntersectionOptions, useInView } from 'react-intersection-observer';
 
@@ -6,45 +5,50 @@ import { SerializedStyles } from '@emotion/react';
 
 import * as styles from './fade-in-wrapper.styles';
 
-/** JSX에서 사용할 수 있는 HTML 엘리먼트의 타입 */
+/** JSX에서 사용할 수 있는 HTML 태그 이름 타입 */
 type Elements = keyof JSX.IntrinsicElements;
 
 /**
- * 1. HTML 엘리먼트 이름을 타입으로 받는 타입 (`div`, `span` 등)
- * 2. props를 받아서 JSX 엘리먼트를 반환하는 함수형 컴포넌트를 타입으로 받는 타입
- *
- * @template P - props 타입
+ * as로 받을 수 있는 엘리먼트 타입
+ * - HTML 태그 이름 (div, span 등)
+ * - props를 받아 JSX 엘리먼트를 반환하는 React 컴포넌트
  */
-type ElementType<P = any> =
-  | { [K in Elements]: P extends JSX.IntrinsicElements[K] ? K : never }[Elements]
-  | ((props: P) => JSX.Element);
+type ElementType = Elements | React.ComponentType<unknown>;
 
 /**
- * ElementType에 따른 동적 타입
- * - `E`가 HTML 엘리먼트라면 해당 엘리먼트의 props 타입 반환
- * - 그렇지 않으면 해당 컴포넌트의 props를 추론
- *
- * @template E - 엘리먼트 타입
+ * ElementType에 따른 props 타입
+ * - E가 HTML 태그라면 JSX.IntrinsicElements[E]
+ * - E가 React 컴포넌트라면 해당 컴포넌트의 props 타입
  */
 type ElementProps<E extends ElementType> = E extends Elements
   ? JSX.IntrinsicElements[E]
-  : React.ComponentProps<E>;
+  : E extends React.ComponentType<infer P>
+    ? P
+    : never;
+
+/** FadeInWrapper가 공통으로 가지는 고유 props */
+type FadeInWrapperOwnProps = {
+  children: ReactNode;
+  /** Emotion으로 전달할 추가 스타일 */
+  additionalStyles?: SerializedStyles;
+  /** 페이드 인 애니메이션 옵션 */
+  transitionOptions?: styles.TransitionOptionsType;
+  /** 뷰포트 진입 감지 옵션 (react-intersection-observer) */
+  intersectionOptions?: IntersectionOptions;
+};
 
 /**
- * `as` 프로퍼티를 포함하여 `ElementProps`를 합친 타입
- * `as`를 통해 다른 HTML 엘리먼트나 컴포넌트를 지정
+ * as 프로퍼티를 포함한 FadeInWrapper의 전체 props 타입
+ * - as로 HTML 태그 또는 React 컴포넌트를 지정할 수 있음
+ * - 지정된 as에 따라 나머지 props 타입이 자동으로 추론됨
  *
- * @template E - 엘리먼트 타입
+ * @template E - 엘리먼트 타입 (div가 기본값)
  */
-type FadeInWrapperProps<E extends ElementType> = {
-  as?: E; // `as` 프로퍼티는 HTML 엘리먼트나 컴포넌트를 동적으로 지정 가능
-  children: ReactNode;
-  additionalStyles?: SerializedStyles; // 추가적인 Emotion 스타일
-  transitionOptions?: styles.TransitionOptionsType; // 애니메이션 관련 CSS 옵션
-  intersectionOptions?: IntersectionOptions; // 뷰포트 진입 감지를 위한 옵션 (react-intersection-observer)
-} & Omit<ElementProps<E>, 'as'>;
+type FadeInWrapperProps<E extends ElementType = 'div'> = FadeInWrapperOwnProps & {
+  as?: E;
+} & Omit<ElementProps<E>, keyof FadeInWrapperOwnProps | 'as'>;
 
-export default function FadeInWrapper<E extends ElementType>({
+export default function FadeInWrapper<E extends ElementType = 'div'>({
   as,
   children,
   additionalStyles,
@@ -52,11 +56,11 @@ export default function FadeInWrapper<E extends ElementType>({
   intersectionOptions,
   ...props
 }: FadeInWrapperProps<E>) {
-  const $Element = as || 'div';
+  const Element = (as || 'div') as React.ElementType;
   const { ref, inView } = useInView(intersectionOptions);
 
   return (
-    <$Element
+    <Element
       ref={ref}
       css={[
         styles.fadeInWrapper({
@@ -68,6 +72,6 @@ export default function FadeInWrapper<E extends ElementType>({
       {...props}
     >
       {children}
-    </$Element>
+    </Element>
   );
 }


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #307 

## 🌱 주요 변경 사항
FadeInWrapper 컴포넌트에서 사용하던 element 타입 제네릭의 기본값 any를 제거하고, JSX에서 사용 가능한 HTML 태그 이름과 React 컴포넌트를 받는 유니온 타입으로 변경하였습니다.
